### PR TITLE
feat: bootstrap central config from node config dist URL on first run

### DIFF
--- a/core/nylon.go
+++ b/core/nylon.go
@@ -74,8 +74,8 @@ func (n *Nylon) Init(s *state.State) error {
 	}
 
 	// check for central config updates
-	if s.Dist != nil {
-		for _, repo := range s.Dist.Repos {
+	if s.CentralCfg.Dist != nil {
+		for _, repo := range s.CentralCfg.Dist.Repos {
 			s.Log.Info("config source", "repo", repo)
 		}
 		s.Env.RepeatTask(checkForConfigUpdates, state.CentralUpdateDelay)

--- a/core/nylon_distribution.go
+++ b/core/nylon_distribution.go
@@ -12,48 +12,58 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// fetches and unbundles central config from url
+func FetchConfig(repoStr string, key state.NyPublicKey) (*state.CentralCfg, error) {
+	repo, err := url.Parse(repoStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse repo URL %s: %w", repoStr, err)
+	}
+	cfgBody := make([]byte, 0)
+
+	if repo.Scheme == "file" {
+		file, err := os.ReadFile(repo.Opaque)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", repo.Opaque, err)
+		}
+		cfgBody = file
+	} else if repo.Scheme == "http" || repo.Scheme == "https" {
+		res, err := http.Get(repo.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch %s: %w", repo.String(), err)
+		}
+		cfgBody, err = io.ReadAll(res.Body)
+		if err != nil {
+			res.Body.Close()
+			return nil, fmt.Errorf("failed to read response from %s: %w", repo.String(), err)
+		}
+		err = res.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to close response from %s: %w", repo.String(), err)
+		}
+	}
+
+	config, err := state.UnbundleConfig(string(cfgBody), key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unbundle config from %s: %w", repoStr, err)
+	}
+	return config, nil
+}
+
 // responsible for central config distribution
 func checkForConfigUpdates(s *state.State) error {
-	if s.Dist == nil {
+	if s.CentralCfg.Dist == nil {
 		return errors.New("nylon is not configured for automatic config distribution")
 	}
-	for _, repoStr := range s.Dist.Repos {
-		repo, err := url.Parse(repoStr)
-		if err != nil {
-			return err
-		}
+	for _, repoStr := range s.CentralCfg.Dist.Repos {
 		e := s.Env
-		go func() {
+		go func(repo string) {
 			err := func() error {
-				cfgBody := make([]byte, 0)
-
-				if repo.Scheme == "file" {
-					file, err := os.ReadFile(repo.Opaque)
-					if err != nil {
-						return err
-					}
-					cfgBody = file
-				} else if repo.Scheme == "http" || repo.Scheme == "https" {
-					res, err := http.Get(repo.String())
-					if err != nil {
-						return err
-					}
-					cfgBody, err = io.ReadAll(res.Body)
-					if err != nil {
-						return err
-					}
-					err = res.Body.Close()
-					if err != nil {
-						return err
-					}
-				}
-
-				config, err := state.UnbundleConfig(string(cfgBody), e.Dist.Key)
+				config, err := FetchConfig(repo, e.CentralCfg.Dist.Key)
 				if err != nil {
 					return err
 				}
 				if config.Timestamp > e.Timestamp && !s.Updating.Swap(true) {
-					e.Log.Info("Found a new config update in repo", "repo", repo.String())
+					e.Log.Info("Found a new config update in repo", "repo", repo)
 					bytes, err := yaml.Marshal(config)
 					if err != nil {
 						e.Log.Error("Error marshalling new config", "err", err.Error())
@@ -69,14 +79,14 @@ func checkForConfigUpdates(s *state.State) error {
 				err:
 					s.Updating.Store(false)
 				} else if state.DBG_log_repo_updates {
-					e.Log.Debug(fmt.Sprintf("found old update bundle at %s, skipping", repo.String()))
+					e.Log.Debug(fmt.Sprintf("found old update bundle at %s, skipping", repo))
 				}
 				return nil
 			}()
 			if err != nil && state.DBG_log_repo_updates {
 				e.Log.Error("Error updating config", "err", err.Error())
 			}
-		}()
+		}(repoStr)
 	}
 	return nil
 }

--- a/example/sample-node.yaml
+++ b/example/sample-node.yaml
@@ -6,6 +6,6 @@ usesystemrouting: false # Default: false - if enabled, Nylon will use the system
 logpath: "" # Default: "" - If set, Nylon will log to this file
 interfacename: "" # Default: "" - If set, Nylon will use this interface name instead of the default "nylon" or utunx on macOS
 disablerouting: false # Default: false - If true, Nylon will not route traffic through this node
-dist: # Optional: If set, Nylon will bootstrap central.yaml from this URL on first run
+dist: # Optional: If set, Nylon will bootstrap central.yaml from this URL if it does not exist already
   url: https://static.example.com/network1.nybundle
   key: 7PaN6DmAayz4KnDnsXSXJH+Oy0TFGeoM4FEbQfLriVY=

--- a/example/sample-node.yaml
+++ b/example/sample-node.yaml
@@ -6,3 +6,6 @@ usesystemrouting: false # Default: false - if enabled, Nylon will use the system
 logpath: "" # Default: "" - If set, Nylon will log to this file
 interfacename: "" # Default: "" - If set, Nylon will use this interface name instead of the default "nylon" or utunx on macOS
 disablerouting: false # Default: false - If true, Nylon will not route traffic through this node
+dist: # Optional: If set, Nylon will bootstrap central.yaml from this URL on first run
+  url: https://static.example.com/network1.nybundle
+  key: 7PaN6DmAayz4KnDnsXSXJH+Oy0TFGeoM4FEbQfLriVY=

--- a/state/config.go
+++ b/state/config.go
@@ -29,6 +29,11 @@ type DistributionCfg struct {
 	Repos []string
 }
 
+type LocalDistributionCfg struct {
+	Key NyPublicKey
+	Url string
+}
+
 type CentralCfg struct {
 	Dist      *DistributionCfg `yaml:",omitempty"`
 	Routers   []RouterCfg
@@ -65,6 +70,7 @@ type LocalCfg struct {
 	Id  NodeId
 	// Address that the data plane can be accessed by
 	Port             uint16
+	Dist             *LocalDistributionCfg `yaml:",omitempty"`
 	DisableRouting   bool
 	UseSystemRouting bool
 	NoNetConfigure   bool `yaml:",omitempty"`

--- a/state/validation.go
+++ b/state/validation.go
@@ -55,6 +55,12 @@ func NodeConfigValidator(node *LocalCfg) error {
 			return fmt.Errorf("interface name is invalid: %v", err)
 		}
 	}
+	if node.Dist != nil {
+		_, err := url.Parse(node.Dist.Url)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
If the central config is missing and the node config includes a `dist` section with url and key, nylon will fetch and save the central config on first run.

This was already mentioned in the [example/README.md](https://github.com/encodeous/nylon/blob/d925f4727729740d675e9699234197f0da10ae8f/example/README.md?plain=1#L12) but appearently it wasn’t actually implemented. I find this quite useful for deploying nodes that can "self configure" from a remote bundle without having to manually copy the central config to every node.