### PR TITLE
perf: reduce heap allocations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,3 +39,4 @@ log.csv
 vendor
 
 workdir
+Dockerfile

--- a/polyamide/device/traffic_control.go
+++ b/polyamide/device/traffic_control.go
@@ -1,8 +1,9 @@
 package device
 
 import (
-	"github.com/encodeous/nylon/polyamide/conn"
 	"slices"
+
+	"github.com/encodeous/nylon/polyamide/conn"
 )
 
 // polyamide traffic control provides a facility to re-order, manipulate, and redirect packets between nylon/polyamide nodes
@@ -200,6 +201,7 @@ func (device *Device) TCBatch(batch []*TCElement, tcs *TCState) {
 				obe.packet = elem.Packet
 				obe.buffer = elem.Buffer
 				obec.elems = append(obec.elems, obe)
+				device.PutTCElement(elem)
 				elems[i] = nil
 			}
 			peer.StagePackets(obec)


### PR DESCRIPTION
This PR properly frees TCElement in the hot path, as well as reducing map allocations in the endpoint-based grouping logic.