### PR TITLE
feat(core): add control plane with REST API, WebSocket, and embedded web UI

### DIFF
--- a/core/control_plane.go
+++ b/core/control_plane.go
@@ -648,7 +648,7 @@ type neighbourTopology struct {
 	IsRouter   bool   `json:"is_router"`
 	Neighbours []struct {
 		ID         string `json:"id"`
-		BestMetric int    `json:"best_metric"`
+		BestMetric uint32 `json:"best_metric"`
 	} `json:"neighbours"`
 }
 
@@ -669,7 +669,7 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 	type topoEdge struct {
 		From   string `json:"from"`
 		To     string `json:"to"`
-		Metric int    `json:"metric"`
+		Metric uint32 `json:"metric"`
 	}
 
 	visited := make(map[string]bool)
@@ -684,7 +684,7 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 	// Get our own neighbours via dispatch
 	type ownNeigh struct {
 		Id         string
-		BestMetric int
+		BestMetric uint32
 	}
 	neighResult := make(chan []ownNeigh, 1)
 	cp.env.Dispatch(func(s *state.State) error {
@@ -693,7 +693,7 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 			on := ownNeigh{Id: string(n.Id)}
 			best := n.BestEndpoint()
 			if best != nil {
-				on.BestMetric = int(best.Metric())
+				on.BestMetric = best.Metric()
 			}
 			list = append(list, on)
 		}
@@ -710,7 +710,7 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, nb := range ownNeighs {
-		if nb.BestMetric >= 0xFFFFFFFF { // unreachable (Babel infinity)
+		if nb.BestMetric >= state.INF { // unreachable (Babel infinity)
 			nodeMap[nb.Id] = topoNode{ID: nb.Id, IsRouter: cp.env.IsRouter(state.NodeId(nb.Id))}
 			continue
 		}
@@ -757,7 +757,7 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 		nodeMap[item.id] = topoNode{ID: topo.NodeID, IsRouter: topo.IsRouter}
 
 		for _, nb := range topo.Neighbours {
-			if nb.BestMetric >= 0xFFFFFFFF { // unreachable
+			if nb.BestMetric >= state.INF { // unreachable
 				if _, exists := nodeMap[nb.ID]; !exists {
 					nodeMap[nb.ID] = topoNode{ID: nb.ID, IsRouter: cp.env.IsRouter(state.NodeId(nb.ID))}
 				}
@@ -823,7 +823,7 @@ func (cp *ControlPlane) queryNodeTopology(ctx context.Context, addr string) *nei
 
 	var neighs []struct {
 		ID         string `json:"id"`
-		BestMetric int    `json:"best_metric"`
+		BestMetric uint32 `json:"best_metric"`
 	}
 	if err := json.NewDecoder(neighResp.Body).Decode(&neighs); err != nil {
 		return nil

--- a/core/control_plane.go
+++ b/core/control_plane.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
@@ -30,10 +31,11 @@ const (
 // ControlPlane is a NyModule that exposes a REST API + WebSocket
 // for inspecting and managing nylon mesh state.
 type ControlPlane struct {
-	env      *state.Env
-	server   *http.Server
-	trace    *NylonTrace
-	wsClients wsClientSet
+	env        *state.Env
+	server     *http.Server
+	meshServer *http.Server
+	trace      *NylonTrace
+	wsClients  wsClientSet
 }
 
 // wsClientSet tracks active WebSocket connections for clean shutdown.
@@ -165,6 +167,9 @@ func (cp *ControlPlane) Init(s *state.State) error {
 	// Phase 2: WebSocket
 	mux.Handle(apiV1Prefix+"/ws", websocket.Handler(cp.handleWebSocket))
 
+	// Phase 3: Topology aggregation (queries neighbours over mesh)
+	mux.HandleFunc("GET "+apiV1Prefix+"/topology", cp.handleTopology)
+
 	// Phase 3: Embedded Web UI (SPA)
 	uiSub, err := fs.Sub(uiFS, "ui")
 	if err != nil {
@@ -178,17 +183,20 @@ func (cp *ControlPlane) Init(s *state.State) error {
 		})
 	}
 
-	cp.server = &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       30 * time.Second,
-	}
+	handler := mux
 
+	// Listen on localhost
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		s.Log.Warn("control plane failed to bind, skipping", "addr", addr, "error", err)
 		return nil // non-fatal: control plane is optional
+	}
+
+	cp.server = &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       30 * time.Second,
 	}
 
 	go func() {
@@ -197,6 +205,10 @@ func (cp *ControlPlane) Init(s *state.State) error {
 			s.Log.Error("control plane server error", "error", err)
 		}
 	}()
+
+	// Also listen on mesh interface IP so other nodes can query our API
+	meshListener := cp.listenMesh(s, handler)
+	cp.meshServer = meshListener
 
 	return nil
 }
@@ -570,4 +582,247 @@ func writeError(w http.ResponseWriter, code int, msg string) {
 		"error": msg,
 		"code":  fmt.Sprintf("%d", code),
 	})
+}
+
+// --- Mesh listener ---
+
+// listenMesh binds the control plane HTTP server on the node's first mesh address
+// so other nylon nodes can query the API through the mesh tunnel.
+func (cp *ControlPlane) listenMesh(s *state.State, handler http.Handler) *http.Server {
+	// Find this node's mesh addresses
+	node := s.Env.TryGetNode(s.Env.LocalCfg.Id)
+	if node == nil {
+		return nil
+	}
+
+	var meshAddr string
+	for _, addr := range node.Addresses {
+		meshAddr = netip.AddrPortFrom(addr, defaultControlPlanePort).String()
+		break
+	}
+	if meshAddr == "" {
+		return nil
+	}
+
+	ln, err := net.Listen("tcp", meshAddr)
+	if err != nil {
+		s.Log.Warn("control plane: mesh listener failed to bind", "addr", meshAddr, "error", err)
+		return nil
+	}
+
+	srv := &http.Server{
+		Addr:              meshAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+
+	go func() {
+		s.Log.Info("control plane mesh listener started", "addr", meshAddr)
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.Log.Error("control plane mesh listener error", "error", err)
+		}
+	}()
+
+	return srv
+}
+
+// --- Topology aggregation ---
+
+const (
+	defaultControlPlanePort = 58175
+	topologyQueryTimeout   = 5 * time.Second
+)
+
+// neighbourTopology is the JSON shape we fetch from each neighbour's /api/v1/status + /api/v1/neighbours.
+type neighbourTopology struct {
+	NodeID     string `json:"node_id"`
+	IsRouter   bool   `json:"is_router"`
+	Neighbours []struct {
+		ID         string `json:"id"`
+		BestMetric int    `json:"best_metric"`
+	} `json:"neighbours"`
+}
+
+// handleTopology aggregates topology from the entire mesh by querying each reachable node's API.
+// Algorithm:
+//  1. Start with our own neighbours (from dispatch)
+//  2. For each known node, query its /api/v1/status + /api/v1/neighbours via mesh network
+//  3. Build a complete graph of all nodes and edges
+func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), topologyQueryTimeout)
+	defer cancel()
+
+	type topoNode struct {
+		ID       string `json:"id"`
+		IsRouter bool   `json:"is_router"`
+		IsSelf   bool   `json:"is_self"`
+	}
+	type topoEdge struct {
+		From   string `json:"from"`
+		To     string `json:"to"`
+		Metric int    `json:"metric"`
+	}
+
+	visited := make(map[string]bool)
+	var allEdges []topoEdge
+	nodeMap := make(map[string]topoNode)
+
+	myID := string(cp.env.LocalCfg.Id)
+
+	// Add self
+	nodeMap[myID] = topoNode{ID: myID, IsRouter: cp.env.IsRouter(state.NodeId(myID)), IsSelf: true}
+
+	// Get our own neighbours via dispatch
+	type ownNeigh struct {
+		Id         string
+		BestMetric int
+	}
+	neighResult := make(chan []ownNeigh, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		var list []ownNeigh
+		for _, n := range s.Neighbours {
+			on := ownNeigh{Id: string(n.Id)}
+			best := n.BestEndpoint()
+			if best != nil {
+				on.BestMetric = int(best.Metric())
+			}
+			list = append(list, on)
+		}
+		neighResult <- list
+		return nil
+	})
+
+	var ownNeighs []ownNeigh
+	select {
+	case ownNeighs = <-neighResult:
+	case <-time.After(3 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+		return
+	}
+
+	for _, nb := range ownNeighs {
+		edgeKey := myID + "-" + nb.Id
+		if !visited[edgeKey] {
+			visited[edgeKey] = true
+			allEdges = append(allEdges, topoEdge{From: myID, To: nb.Id, Metric: nb.BestMetric})
+		}
+		nodeMap[nb.Id] = topoNode{ID: nb.Id, IsRouter: cp.env.IsRouter(state.NodeId(nb.Id))}
+	}
+
+	// Query each known node's API via mesh network for their neighbour view
+	type pendingNode struct {
+		id   string
+		addr string
+	}
+
+	var queue []pendingNode
+	for _, nb := range ownNeighs {
+		addr := cp.resolveNodeAddr(nb.Id)
+		if addr != "" {
+			queue = append(queue, pendingNode{id: nb.Id, addr: addr})
+		}
+	}
+
+	queried := make(map[string]bool)
+	queried[myID] = true
+
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		if queried[item.id] {
+			continue
+		}
+		queried[item.id] = true
+
+		topo := cp.queryNodeTopology(ctx, item.addr)
+		if topo == nil {
+			continue
+		}
+
+		// Update node info from remote
+		nodeMap[item.id] = topoNode{ID: topo.NodeID, IsRouter: topo.IsRouter}
+
+		for _, nb := range topo.Neighbours {
+			edgeA := item.id + "-" + nb.ID
+			edgeB := nb.ID + "-" + item.id
+			if !visited[edgeA] && !visited[edgeB] {
+				visited[edgeA] = true
+				allEdges = append(allEdges, topoEdge{From: item.id, To: nb.ID, Metric: nb.BestMetric})
+			}
+
+			if _, exists := nodeMap[nb.ID]; !exists {
+				nodeMap[nb.ID] = topoNode{ID: nb.ID, IsRouter: cp.env.IsRouter(state.NodeId(nb.ID))}
+			}
+
+			if !queried[nb.ID] {
+				addr := cp.resolveNodeAddr(nb.ID)
+				if addr != "" {
+					queue = append(queue, pendingNode{id: nb.ID, addr: addr})
+				}
+			}
+		}
+	}
+
+	// Build result
+	var allNodes []topoNode
+	for _, n := range nodeMap {
+		allNodes = append(allNodes, n)
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"nodes": allNodes,
+		"edges": allEdges,
+	})
+}
+
+// queryNodeTopology fetches /api/v1/status + /api/v1/neighbours from a remote node via mesh.
+func (cp *ControlPlane) queryNodeTopology(ctx context.Context, addr string) *neighbourTopology {
+	client := &http.Client{Timeout: topologyQueryTimeout}
+
+	// Fetch status
+	statusResp, err := client.Get("http://" + addr + apiV1Prefix + "/status")
+	if err != nil {
+		return nil
+	}
+	defer statusResp.Body.Close()
+
+	var status struct {
+		NodeID   string `json:"node_id"`
+		IsRouter bool   `json:"is_router"`
+	}
+	if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
+		return nil
+	}
+
+	// Fetch neighbours
+	neighResp, err := client.Get("http://" + addr + apiV1Prefix + "/neighbours")
+	if err != nil {
+		return nil
+	}
+	defer neighResp.Body.Close()
+
+	var neighs []struct {
+		ID         string `json:"id"`
+		BestMetric int    `json:"best_metric"`
+	}
+	if err := json.NewDecoder(neighResp.Body).Decode(&neighs); err != nil {
+		return nil
+	}
+
+	return &neighbourTopology{
+		NodeID:     status.NodeID,
+		IsRouter:   status.IsRouter,
+		Neighbours: neighs,
+	}
+}
+
+// resolveNodeAddr returns the mesh IP:port for a given node ID.
+func (cp *ControlPlane) resolveNodeAddr(nodeId string) string {
+	node := cp.env.TryGetNode(state.NodeId(nodeId))
+	if node == nil || len(node.Addresses) == 0 {
+		return ""
+	}
+	return netip.AddrPortFrom(node.Addresses[0], defaultControlPlanePort).String()
 }

--- a/core/control_plane.go
+++ b/core/control_plane.go
@@ -710,6 +710,10 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, nb := range ownNeighs {
+		if nb.BestMetric >= 0xFFFFFFFF { // unreachable (Babel infinity)
+			nodeMap[nb.Id] = topoNode{ID: nb.Id, IsRouter: cp.env.IsRouter(state.NodeId(nb.Id))}
+			continue
+		}
 		edgeKey := myID + "-" + nb.Id
 		if !visited[edgeKey] {
 			visited[edgeKey] = true
@@ -753,6 +757,12 @@ func (cp *ControlPlane) handleTopology(w http.ResponseWriter, r *http.Request) {
 		nodeMap[item.id] = topoNode{ID: topo.NodeID, IsRouter: topo.IsRouter}
 
 		for _, nb := range topo.Neighbours {
+			if nb.BestMetric >= 0xFFFFFFFF { // unreachable
+				if _, exists := nodeMap[nb.ID]; !exists {
+					nodeMap[nb.ID] = topoNode{ID: nb.ID, IsRouter: cp.env.IsRouter(state.NodeId(nb.ID))}
+				}
+				continue
+			}
 			edgeA := item.id + "-" + nb.ID
 			edgeB := nb.ID + "-" + item.id
 			if !visited[edgeA] && !visited[edgeB] {

--- a/core/control_plane.go
+++ b/core/control_plane.go
@@ -207,8 +207,8 @@ func (cp *ControlPlane) Init(s *state.State) error {
 	}()
 
 	// Also listen on mesh interface IP so other nodes can query our API
-	meshListener := cp.listenMesh(s, handler)
-	cp.meshServer = meshListener
+	// Must be delayed because WG interface hasn't been created yet at Init time
+	go cp.listenMeshDelayed(s, handler)
 
 	return nil
 }
@@ -586,13 +586,12 @@ func writeError(w http.ResponseWriter, code int, msg string) {
 
 // --- Mesh listener ---
 
-// listenMesh binds the control plane HTTP server on the node's first mesh prefix address
-// so other nylon nodes can query the API through the mesh tunnel.
-func (cp *ControlPlane) listenMesh(s *state.State, handler http.Handler) *http.Server {
-	// Find this node's mesh address from its prefix
+// listenMeshDelayed waits for the WireGuard interface to come up, then binds
+// the control plane on the node's mesh prefix address.
+func (cp *ControlPlane) listenMeshDelayed(s *state.State, handler http.Handler) {
 	node := s.Env.TryGetNode(s.Env.LocalCfg.Id)
 	if node == nil {
-		return nil
+		return
 	}
 
 	var meshAddr string
@@ -604,13 +603,22 @@ func (cp *ControlPlane) listenMesh(s *state.State, handler http.Handler) *http.S
 		}
 	}
 	if meshAddr == "" {
-		return nil
+		return
 	}
 
-	ln, err := net.Listen("tcp", meshAddr)
+	// Retry binding — WG interface may not exist yet
+	var ln net.Listener
+	var err error
+	for attempt := 0; attempt < 30; attempt++ {
+		ln, err = net.Listen("tcp", meshAddr)
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
 	if err != nil {
-		s.Log.Warn("control plane: mesh listener failed to bind", "addr", meshAddr, "error", err)
-		return nil
+		s.Log.Warn("control plane: mesh listener gave up", "addr", meshAddr, "error", err)
+		return
 	}
 
 	srv := &http.Server{
@@ -619,15 +627,12 @@ func (cp *ControlPlane) listenMesh(s *state.State, handler http.Handler) *http.S
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       30 * time.Second,
 	}
+	cp.meshServer = srv
 
-	go func() {
-		s.Log.Info("control plane mesh listener started", "addr", meshAddr)
-		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
-			s.Log.Error("control plane mesh listener error", "error", err)
-		}
-	}()
-
-	return srv
+	s.Log.Info("control plane mesh listener started", "addr", meshAddr)
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		s.Log.Error("control plane mesh listener error", "error", err)
+	}
 }
 
 // --- Topology aggregation ---

--- a/core/control_plane.go
+++ b/core/control_plane.go
@@ -1,0 +1,573 @@
+package core
+
+import (
+	"context"
+	"embed"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/encodeous/nylon/state"
+	"golang.org/x/net/websocket"
+)
+
+//go:embed ui
+var uiFS embed.FS
+
+const (
+	defaultControlPlaneAddr = "127.0.0.1:58175"
+	apiV1Prefix             = "/api/v1"
+)
+
+// ControlPlane is a NyModule that exposes a REST API + WebSocket
+// for inspecting and managing nylon mesh state.
+type ControlPlane struct {
+	env      *state.Env
+	server   *http.Server
+	trace    *NylonTrace
+	wsClients wsClientSet
+}
+
+// wsClientSet tracks active WebSocket connections for clean shutdown.
+type wsClientSet struct {
+	mu      sync.Mutex
+	clients map[*websocket.Conn]struct{}
+}
+
+func (cs *wsClientSet) add(c *websocket.Conn) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.clients[c] = struct{}{}
+}
+
+func (cs *wsClientSet) remove(c *websocket.Conn) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	delete(cs.clients, c)
+}
+
+func (cs *wsClientSet) closeAll() {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	for c := range cs.clients {
+		c.Close()
+	}
+	cs.clients = make(map[*websocket.Conn]struct{})
+}
+
+// --- JSON response types ---
+
+type NodeInfo struct {
+	Id        string   `json:"id"`
+	IsRouter  bool     `json:"is_router"`
+	Addresses []string `json:"addresses,omitempty"`
+	PublicKey string   `json:"public_key"`
+}
+
+type RouteInfo struct {
+	Prefix    string `json:"prefix"`
+	NextHop   string `json:"next_hop"`
+	RouterId  string `json:"router_id"`
+	Seqno     uint16 `json:"seqno"`
+	Metric    uint32 `json:"metric"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+type NeighbourInfo struct {
+	Id         string         `json:"id"`
+	BestMetric uint32         `json:"best_metric"`
+	Endpoints  []EndpointInfo `json:"endpoints"`
+	Routes     []string       `json:"routes"`
+}
+
+type EndpointInfo struct {
+	Address  string `json:"address"`
+	Resolved string `json:"resolved,omitempty"`
+	Active   bool   `json:"active"`
+	Metric   uint32 `json:"metric"`
+	IsRemote bool   `json:"is_remote"`
+}
+
+type PrefixInfo struct {
+	Prefix    string `json:"prefix"`
+	RouterId  string `json:"router_id"`
+	Metric    uint32 `json:"metric"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+	Type      string `json:"type"`
+}
+
+type ForwardEntry struct {
+	Prefix  string `json:"prefix"`
+	NextHop string `json:"next_hop"`
+}
+
+type StatusResponse struct {
+	NodeId    string `json:"node_id"`
+	IsRouter  bool   `json:"is_router"`
+	StartedAt string `json:"started_at"`
+}
+
+// WSEvent is the envelope for WebSocket messages sent to clients.
+type WSEvent struct {
+	Type string          `json:"type"` // "trace", "state_change", "error"
+	Data json.RawMessage `json:"data"`
+}
+
+// WSCommand is the envelope for WebSocket messages received from clients.
+type WSCommand struct {
+	Type string          `json:"type"` // "subscribe", "ping"
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+// WriteOperationRequest is the body for POST write endpoints.
+type WriteOperationRequest struct {
+	// Reload triggers a config reload (re-read central.yaml and restart)
+	Reload bool `json:"reload,omitempty"`
+}
+
+// APIResponse is a generic response envelope.
+type APIResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+// --- ControlPlane NyModule implementation ---
+
+func (cp *ControlPlane) Init(s *state.State) error {
+	cp.env = s.Env
+	cp.wsClients = wsClientSet{clients: make(map[*websocket.Conn]struct{})}
+
+	addr := defaultControlPlaneAddr
+	// future: allow override via LocalCfg or AuxConfig
+
+	mux := http.NewServeMux()
+	// Phase 1: read-only endpoints
+	mux.HandleFunc("GET "+apiV1Prefix+"/status", cp.handleStatus)
+	mux.HandleFunc("GET "+apiV1Prefix+"/nodes", cp.handleNodes)
+	mux.HandleFunc("GET "+apiV1Prefix+"/routes", cp.handleRoutes)
+	mux.HandleFunc("GET "+apiV1Prefix+"/neighbours", cp.handleNeighbours)
+	mux.HandleFunc("GET "+apiV1Prefix+"/prefixes", cp.handlePrefixes)
+	mux.HandleFunc("GET "+apiV1Prefix+"/forward", cp.handleForward)
+	mux.HandleFunc("GET "+apiV1Prefix+"/sysroutes", cp.handleSysRoutes)
+
+	// Phase 2: write endpoints
+	mux.HandleFunc("POST "+apiV1Prefix+"/reload", cp.handleReload)
+	mux.HandleFunc("POST "+apiV1Prefix+"/flush_routes", cp.handleFlushRoutes)
+
+	// Phase 2: WebSocket
+	mux.Handle(apiV1Prefix+"/ws", websocket.Handler(cp.handleWebSocket))
+
+	// Phase 3: Embedded Web UI (SPA)
+	uiSub, err := fs.Sub(uiFS, "ui")
+	if err != nil {
+		s.Log.Warn("control plane: failed to create UI subtree", "error", err)
+	} else {
+		fileServer := http.FileServer(http.FS(uiSub))
+		mux.Handle("/ui/", http.StripPrefix("/ui/", fileServer))
+		// Root redirect to /ui/
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/ui/", http.StatusFound)
+		})
+	}
+
+	cp.server = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		s.Log.Warn("control plane failed to bind, skipping", "addr", addr, "error", err)
+		return nil // non-fatal: control plane is optional
+	}
+
+	go func() {
+		s.Log.Info("control plane listening", "addr", addr)
+		if err := cp.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.Log.Error("control plane server error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func (cp *ControlPlane) Cleanup(s *state.State) error {
+	// Close all WebSocket clients first
+	cp.wsClients.closeAll()
+
+	if cp.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return cp.server.Shutdown(ctx)
+	}
+	return nil
+}
+
+// --- Phase 1: Read-only API handlers ---
+
+func (cp *ControlPlane) handleStatus(w http.ResponseWriter, r *http.Request) {
+	resp := StatusResponse{
+		NodeId:   string(cp.env.LocalCfg.Id),
+		IsRouter: cp.env.IsRouter(cp.env.LocalCfg.Id),
+	}
+	writeJSON(w, resp)
+}
+
+func (cp *ControlPlane) handleNodes(w http.ResponseWriter, r *http.Request) {
+	nodes := make([]NodeInfo, 0)
+	for _, n := range cp.env.Routers {
+		nodes = append(nodes, nodeCfgToInfo(n.NodeCfg, true))
+	}
+	for _, n := range cp.env.Clients {
+		nodes = append(nodes, nodeCfgToInfo(n.NodeCfg, false))
+	}
+	writeJSON(w, nodes)
+}
+
+func (cp *ControlPlane) handleRoutes(w http.ResponseWriter, r *http.Request) {
+	result := make(chan []RouteInfo, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		routes := make([]RouteInfo, 0, len(s.Routes))
+		for prefix, route := range s.Routes {
+			ri := RouteInfo{
+				Prefix:   prefix.String(),
+				NextHop:  string(route.Nh),
+				RouterId: string(route.NodeId),
+				Seqno:    route.Seqno,
+				Metric:   route.Metric,
+			}
+			if !route.ExpireAt.IsZero() {
+				ri.ExpiresAt = route.ExpireAt.Format(time.RFC3339)
+			}
+			routes = append(routes, ri)
+		}
+		slices.SortFunc(routes, func(a, b RouteInfo) int {
+			return strings.Compare(a.Prefix, b.Prefix)
+		})
+		result <- routes
+		return nil
+	})
+
+	select {
+	case routes := <-result:
+		writeJSON(w, routes)
+	case <-time.After(5 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+	}
+}
+
+func (cp *ControlPlane) handleNeighbours(w http.ResponseWriter, r *http.Request) {
+	result := make(chan []NeighbourInfo, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		neighbours := make([]NeighbourInfo, 0, len(s.Neighbours))
+		for _, n := range s.Neighbours {
+			ni := NeighbourInfo{
+				Id: string(n.Id),
+			}
+			best := n.BestEndpoint()
+			if best != nil {
+				ni.BestMetric = best.Metric()
+			}
+			for _, ep := range n.Eps {
+				nep := ep.AsNylonEndpoint()
+				ei := EndpointInfo{
+					Active:   nep.IsActive(),
+					Metric:   nep.Metric(),
+					IsRemote: nep.IsRemote(),
+				}
+				ei.Address = nep.DynEP.String()
+				ap, err := nep.DynEP.Get()
+				if err == nil {
+					ei.Resolved = ap.String()
+				}
+				ni.Endpoints = append(ni.Endpoints, ei)
+			}
+			routes := make([]string, 0, len(n.Routes))
+			for prefix := range n.Routes {
+				routes = append(routes, prefix.String())
+			}
+			slices.Sort(routes)
+			ni.Routes = routes
+			neighbours = append(neighbours, ni)
+		}
+		slices.SortFunc(neighbours, func(a, b NeighbourInfo) int {
+			return strings.Compare(a.Id, b.Id)
+		})
+		result <- neighbours
+		return nil
+	})
+
+	select {
+	case neighbours := <-result:
+		writeJSON(w, neighbours)
+	case <-time.After(5 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+	}
+}
+
+func (cp *ControlPlane) handlePrefixes(w http.ResponseWriter, r *http.Request) {
+	result := make(chan []PrefixInfo, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		prefixes := make([]PrefixInfo, 0, len(s.Advertised))
+		for prefix, adv := range s.Advertised {
+			pi := PrefixInfo{
+				Prefix:   prefix.String(),
+				RouterId: string(adv.NodeId),
+				Metric:   adv.MetricFn(),
+			}
+			if !adv.Expiry.IsZero() {
+				timeRem := time.Until(adv.Expiry)
+				if timeRem > 24*time.Hour {
+					pi.ExpiresAt = "never"
+				} else {
+					pi.ExpiresAt = adv.Expiry.Format(time.RFC3339)
+				}
+			}
+			if adv.IsPassiveHold {
+				pi.Type = "passive"
+			} else {
+				pi.Type = "active"
+			}
+			prefixes = append(prefixes, pi)
+		}
+		slices.SortFunc(prefixes, func(a, b PrefixInfo) int {
+			return strings.Compare(a.Prefix, b.Prefix)
+		})
+		result <- prefixes
+		return nil
+	})
+
+	select {
+	case prefixes := <-result:
+		writeJSON(w, prefixes)
+	case <-time.After(5 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+	}
+}
+
+func (cp *ControlPlane) handleForward(w http.ResponseWriter, r *http.Request) {
+	result := make(chan []ForwardEntry, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		router := Get[*NylonRouter](s)
+		entries := make([]ForwardEntry, 0)
+		for prefix, entry := range router.ForwardTable.All() {
+			entries = append(entries, ForwardEntry{
+				Prefix:  prefix.String(),
+				NextHop: string(entry.Nh),
+			})
+		}
+		slices.SortFunc(entries, func(a, b ForwardEntry) int {
+			return strings.Compare(a.Prefix, b.Prefix)
+		})
+		result <- entries
+		return nil
+	})
+
+	select {
+	case entries := <-result:
+		writeJSON(w, entries)
+	case <-time.After(5 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+	}
+}
+
+func (cp *ControlPlane) handleSysRoutes(w http.ResponseWriter, r *http.Request) {
+	result := make(chan []string, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		router := Get[*NylonRouter](s)
+		sysRoutes := router.ComputeSysRouteTable()
+		routes := make([]string, 0, len(sysRoutes))
+		for _, p := range sysRoutes {
+			routes = append(routes, p.String())
+		}
+		slices.Sort(routes)
+		result <- routes
+		return nil
+	})
+
+	select {
+	case routes := <-result:
+		writeJSON(w, routes)
+	case <-time.After(5 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+	}
+}
+
+// --- Phase 2: Write operation handlers ---
+
+// handleReload triggers a config reload by setting Updating and cancelling the context.
+// The Bootstrap loop in entrypoint.go will re-read configs and restart.
+func (cp *ControlPlane) handleReload(w http.ResponseWriter, r *http.Request) {
+	if cp.env.Stopping.Load() {
+		writeError(w, http.StatusConflict, "node is shutting down")
+		return
+	}
+	if !cp.env.Updating.CompareAndSwap(false, true) {
+		writeError(w, http.StatusConflict, "reload already in progress")
+		return
+	}
+
+	cp.env.Log.Info("control plane: config reload triggered via API")
+	cp.env.Cancel(fmt.Errorf("config reload triggered via control plane API"))
+
+	writeJSON(w, APIResponse{
+		Success: true,
+		Message: "reload initiated, node will restart with updated config",
+	})
+}
+
+// handleFlushRoutes triggers a full route table update to all neighbours.
+func (cp *ControlPlane) handleFlushRoutes(w http.ResponseWriter, r *http.Request) {
+	if cp.env.Stopping.Load() {
+		writeError(w, http.StatusConflict, "node is shutting down")
+		return
+	}
+
+	result := make(chan string, 1)
+	cp.env.Dispatch(func(s *state.State) error {
+		router := Get[*NylonRouter](s)
+		FullTableUpdate(s.RouterState, router)
+		neighCount := len(router.IO)
+		result <- fmt.Sprintf("flushed full route table to %d neighbours", neighCount)
+		return nil
+	})
+
+	select {
+	case msg := <-result:
+		writeJSON(w, APIResponse{
+			Success: true,
+			Message: msg,
+		})
+	case <-time.After(5 * time.Second):
+		writeError(w, http.StatusServiceUnavailable, "dispatch timeout")
+	}
+}
+
+// --- Phase 2: WebSocket handler ---
+
+func (cp *ControlPlane) handleWebSocket(ws *websocket.Conn) {
+	// Resolve NylonTrace at first use (module may init after ControlPlane)
+	if cp.trace == nil {
+		cp.env.Dispatch(func(s *state.State) error {
+			cp.trace = Get[*NylonTrace](s)
+			return nil
+		})
+	}
+
+	cp.wsClients.add(ws)
+	defer func() {
+		cp.wsClients.remove(ws)
+		ws.Close()
+	}()
+
+	// Subscribe to trace events
+	traceCh := make(chan interface{}, 64)
+	if cp.trace != nil {
+		cp.trace.Register(traceCh)
+		defer cp.trace.Unregister(traceCh)
+	}
+
+	// Read loop: handle incoming commands from client
+	readCh := make(chan WSCommand, 16)
+	go func() {
+		defer close(readCh)
+		for {
+			var cmd WSCommand
+			err := websocket.JSON.Receive(ws, &cmd)
+			if err != nil {
+				return // connection closed or error
+			}
+			readCh <- cmd
+		}
+	}()
+
+	// Main event loop: forward trace events and handle commands
+	for {
+		select {
+		case msg, ok := <-traceCh:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(map[string]interface{}{
+				"message": fmt.Sprintf("%v", msg),
+				"ts":      time.Now().Format(time.RFC3339Nano),
+			})
+			if err != nil {
+				continue
+			}
+			event := WSEvent{
+				Type: "trace",
+				Data: data,
+			}
+			if err := websocket.JSON.Send(ws, event); err != nil {
+				return // client disconnected
+			}
+
+		case cmd, ok := <-readCh:
+			if !ok {
+				return // read loop ended (client disconnected)
+			}
+			cp.handleWSCommand(ws, cmd)
+
+		case <-cp.env.Context.Done():
+			// Server shutting down
+			return
+		}
+	}
+}
+
+// handleWSCommand processes commands received from WebSocket clients.
+func (cp *ControlPlane) handleWSCommand(ws *websocket.Conn, cmd WSCommand) {
+	switch cmd.Type {
+	case "ping":
+		pong, _ := json.Marshal(map[string]string{"pong": time.Now().Format(time.RFC3339Nano)})
+		websocket.JSON.Send(ws, WSEvent{Type: "pong", Data: pong})
+	default:
+		errData, _ := json.Marshal(map[string]string{"error": "unknown command: " + cmd.Type})
+		websocket.JSON.Send(ws, WSEvent{Type: "error", Data: errData})
+	}
+}
+
+// --- helpers ---
+
+func nodeCfgToInfo(n state.NodeCfg, isRouter bool) NodeInfo {
+	addrs := make([]string, 0, len(n.Addresses))
+	for _, a := range n.Addresses {
+		addrs = append(addrs, a.String())
+	}
+	return NodeInfo{
+		Id:        string(n.Id),
+		IsRouter:  isRouter,
+		Addresses: addrs,
+		PublicKey: base64.StdEncoding.EncodeToString(n.PubKey[:]),
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		slog.Error("control plane: failed to encode JSON", "error", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error": msg,
+		"code":  fmt.Sprintf("%d", code),
+	})
+}

--- a/core/control_plane.go
+++ b/core/control_plane.go
@@ -586,19 +586,22 @@ func writeError(w http.ResponseWriter, code int, msg string) {
 
 // --- Mesh listener ---
 
-// listenMesh binds the control plane HTTP server on the node's first mesh address
+// listenMesh binds the control plane HTTP server on the node's first mesh prefix address
 // so other nylon nodes can query the API through the mesh tunnel.
 func (cp *ControlPlane) listenMesh(s *state.State, handler http.Handler) *http.Server {
-	// Find this node's mesh addresses
+	// Find this node's mesh address from its prefix
 	node := s.Env.TryGetNode(s.Env.LocalCfg.Id)
 	if node == nil {
 		return nil
 	}
 
 	var meshAddr string
-	for _, addr := range node.Addresses {
-		meshAddr = netip.AddrPortFrom(addr, defaultControlPlanePort).String()
-		break
+	for _, pfx := range node.Prefixes {
+		addr := pfx.GetPrefix().Addr()
+		if addr.IsValid() {
+			meshAddr = netip.AddrPortFrom(addr, defaultControlPlanePort).String()
+			break
+		}
 	}
 	if meshAddr == "" {
 		return nil
@@ -821,8 +824,14 @@ func (cp *ControlPlane) queryNodeTopology(ctx context.Context, addr string) *nei
 // resolveNodeAddr returns the mesh IP:port for a given node ID.
 func (cp *ControlPlane) resolveNodeAddr(nodeId string) string {
 	node := cp.env.TryGetNode(state.NodeId(nodeId))
-	if node == nil || len(node.Addresses) == 0 {
+	if node == nil {
 		return ""
 	}
-	return netip.AddrPortFrom(node.Addresses[0], defaultControlPlanePort).String()
+	for _, pfx := range node.Prefixes {
+		addr := pfx.GetPrefix().Addr()
+		if addr.IsValid() {
+			return netip.AddrPortFrom(addr, defaultControlPlanePort).String()
+		}
+	}
+	return ""
 }

--- a/core/entrypoint.go
+++ b/core/entrypoint.go
@@ -244,6 +244,7 @@ func initModules(s *state.State) error {
 	var modules []state.NyModule
 	modules = append(modules, &NylonTrace{})
 	modules = append(modules, &NylonRouter{})
+	modules = append(modules, &ControlPlane{})
 	modules = append(modules, &Nylon{})
 
 	for _, module := range modules {

--- a/core/nylon.go
+++ b/core/nylon.go
@@ -19,6 +19,7 @@ type Nylon struct {
 	wgUapi              net.Listener
 	env                 *state.Env
 	itfName             string
+	fwmark              uint32
 	prevInstalledRoutes []netip.Prefix
 }
 

--- a/core/nylon_wireguard.go
+++ b/core/nylon_wireguard.go
@@ -27,6 +27,12 @@ func (n *Nylon) initWireGuard(s *state.State) error {
 	n.Tun = tdev
 	n.itfName = itfName
 
+	fwmark := s.Fwmark
+	if fwmark == 0 {
+		fwmark = uint32(s.Port)
+	}
+	n.fwmark = fwmark
+
 	n.InstallTC(s)
 	s.Log.Info("installed nylon traffic control filter for polysock")
 
@@ -39,9 +45,11 @@ func (n *Nylon) initWireGuard(s *state.State) error {
 		fmt.Sprintf(
 			`private_key=%s
 listen_port=%d
+fwmark=%d
 `,
 			hex.EncodeToString(s.Key[:]),
 			s.Port,
+			fwmark,
 		),
 	)
 	if err != nil {
@@ -75,7 +83,7 @@ listen_port=%d
 			}
 			endpoint, err := n.Device.Bind().ParseEndpoint(ap.String())
 			if err != nil {
-				return err
+				return fmt.Errorf("peer %s: invalid endpoint %q: %w", peer, ap.String(), err)
 			}
 			endpoints = append(endpoints, endpoint)
 		}
@@ -102,7 +110,7 @@ listen_port=%d
 			}
 		}
 
-		err = InitInterface(s.Log, itfName)
+		err = InitInterface(s.Log, itfName, fwmark)
 		if err != nil {
 			return err
 		}
@@ -125,11 +133,12 @@ listen_port=%d
 func (n *Nylon) cleanupWireGuard(s *state.State) error {
 	// remove routes
 	for _, route := range n.prevInstalledRoutes {
-		err := RemoveRoute(s.Log, n.Tun, n.itfName, route)
+		err := RemoveRoute(s.Log, n.Tun, n.itfName, route, n.fwmark)
 		if err != nil {
 			s.Log.Error("failed to remove route", "err", err)
 		}
 	}
+	CleanupInterface(s.Log, n.itfName, n.fwmark)
 	// run pre-down commands
 	for _, cmd := range s.PreDown {
 		err := ExecSplit(s.Log, cmd)
@@ -189,7 +198,7 @@ func UpdateWireGuard(s *state.State) error {
 			}) {
 				endpoint, err := n.Device.Bind().ParseEndpoint(ap.String())
 				if err != nil {
-					return err
+					return fmt.Errorf("peer %s: invalid endpoint %q: %w", peer, ap.String(), err)
 				}
 				eps = append(eps, endpoint)
 			}
@@ -208,7 +217,7 @@ func UpdateWireGuard(s *state.State) error {
 			if !slices.Contains(newEntries, oldEntry) {
 				// uninstall route
 				s.Log.Debug("removing old route", "prefix", oldEntry.String())
-				err := RemoveRoute(s.Log, n.Tun, n.itfName, oldEntry)
+				err := RemoveRoute(s.Log, n.Tun, n.itfName, oldEntry, n.fwmark)
 				if err != nil {
 					s.Log.Error("failed to remove route", "err", err)
 				}
@@ -218,7 +227,7 @@ func UpdateWireGuard(s *state.State) error {
 			if !slices.Contains(oldEntries, newEntry) {
 				// install route
 				s.Log.Debug("installing new route", "prefix", newEntry.String())
-				err := ConfigureRoute(s.Log, n.Tun, n.itfName, newEntry)
+				err := ConfigureRoute(s.Log, n.Tun, n.itfName, newEntry, n.fwmark)
 				if err != nil {
 					s.Log.Error("failed to configure route", "err", err)
 				}

--- a/core/sys_darwin.go
+++ b/core/sys_darwin.go
@@ -20,9 +20,11 @@ func InitUAPI(e *state.Env, itfName string) (net.Listener, error) {
 	return uapi, nil
 }
 
-func InitInterface(logger *slog.Logger, ifName string) error {
+func InitInterface(logger *slog.Logger, ifName string, fwmark uint32) error {
 	return nil
 }
+
+func CleanupInterface(logger *slog.Logger, ifName string, fwmark uint32) {}
 
 func ConfigureAlias(logger *slog.Logger, ifName string, addr netip.Addr) error {
 	if addr.Is4() {
@@ -53,7 +55,7 @@ func PrefixToMaskString(p netip.Prefix) string {
 	return net.IP(mask).String()
 }
 
-func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix) error {
+func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix, fwmark uint32) error {
 	if route.Addr().Is6() {
 		return Exec(logger, "/sbin/route", "-n", "add", "-inet6", route.String(), "-interface", itfName)
 	} else {
@@ -63,7 +65,7 @@ func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route n
 	}
 }
 
-func RemoveRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix) error {
+func RemoveRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix, fwmark uint32) error {
 	if route.Addr().Is6() {
 		return Exec(logger, "/sbin/route", "-n", "delete", "-inet6", route.String(), "-interface", itfName)
 	} else {

--- a/core/sys_linux.go
+++ b/core/sys_linux.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -20,22 +21,37 @@ func InitUAPI(e *state.Env, itfName string) (net.Listener, error) {
 	return uapi, nil
 }
 
-func InitInterface(logger *slog.Logger, ifName string) error {
-	err := Exec(logger, "ip", "link", "set", ifName, "up")
-	if err != nil {
+func InitInterface(logger *slog.Logger, ifName string, fwmark uint32) error {
+	if err := Exec(logger, "ip", "link", "set", ifName, "up"); err != nil {
 		return err
 	}
-	return nil
+	// Policy routing: packets NOT carrying Nylon's fwmark go through Nylon's route table.
+	// Nylon's own WireGuard UDP socket carries the fwmark and falls through to the main table,
+	// preventing routing loops when other VPNs (e.g. Tailscale) share the same host.
+	table := fmt.Sprintf("%d", fwmark)
+	return Exec(logger, "ip", "rule", "add", "not", "fwmark", table, "table", table, "priority", "32764")
+}
+
+func CleanupInterface(logger *slog.Logger, ifName string, fwmark uint32) {
+	table := fmt.Sprintf("%d", fwmark)
+	if err := Exec(logger, "ip", "rule", "del", "not", "fwmark", table, "table", table, "priority", "32764"); err != nil {
+		logger.Error("failed to remove ip rule", "err", err)
+	}
+	if err := Exec(logger, "ip", "route", "flush", "table", table); err != nil {
+		logger.Error("failed to flush route table", "table", table, "err", err)
+	}
 }
 
 func ConfigureAlias(logger *slog.Logger, ifName string, addr netip.Addr) error {
 	return Exec(logger, "ip", "addr", "add", addr.String(), "dev", ifName)
 }
 
-func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix) error {
-	return Exec(logger, "ip", "route", "add", route.String(), "dev", itfName)
+func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix, fwmark uint32) error {
+	table := fmt.Sprintf("%d", fwmark)
+	return Exec(logger, "ip", "route", "add", route.String(), "dev", itfName, "table", table)
 }
 
-func RemoveRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix) error {
-	return Exec(logger, "ip", "route", "del", route.String(), "dev", itfName)
+func RemoveRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix, fwmark uint32) error {
+	table := fmt.Sprintf("%d", fwmark)
+	return Exec(logger, "ip", "route", "del", route.String(), "dev", itfName, "table", table)
 }

--- a/core/sys_windows.go
+++ b/core/sys_windows.go
@@ -25,15 +25,17 @@ func InitUAPI(e *state.Env, itfName string) (net.Listener, error) {
 	return uapi, nil
 }
 
-func InitInterface(logger *slog.Logger, ifName string) error {
+func InitInterface(logger *slog.Logger, ifName string, fwmark uint32) error {
 	return nil
 }
+
+func CleanupInterface(logger *slog.Logger, ifName string, fwmark uint32) {}
 
 func ConfigureAlias(logger *slog.Logger, ifName string, addr netip.Addr) error {
 	return Exec(logger, "netsh", "interface", "ip", "add", "address", ifName, addr.String())
 }
 
-func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix) error {
+func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix, fwmark uint32) error {
 	ifId := wintypes.LUID((dev.(*tun.NativeTun)).LUID())
 	itf, err := ifId.Interface()
 	if err != nil {
@@ -51,7 +53,7 @@ func ConfigureRoute(logger *slog.Logger, dev tun.Device, itfName string, route n
 	}
 }
 
-func RemoveRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix) error {
+func RemoveRoute(logger *slog.Logger, dev tun.Device, itfName string, route netip.Prefix, fwmark uint32) error {
 	ifId := wintypes.LUID((dev.(*tun.NativeTun)).LUID())
 	itf, err := ifId.Interface()
 	if err != nil {

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -47,6 +47,7 @@ async function loadPage(page) {
   try {
     switch (page) {
       case 'dashboard': await loadDashboard(); break;
+      case 'topology': await loadTopology(); break;
       case 'nodes': await loadNodes(); break;
       case 'routes': await loadRoutes(); break;
       case 'neighbours': await loadNeighbours(); break;
@@ -95,6 +96,158 @@ async function loadDashboard() {
         <td>${(n.addresses || []).map(a => '<code>' + esc(a) + '</code>').join(', ') || '—'}</td>
       </tr>
     `).join('');
+  }
+}
+
+// --- Topology ---
+
+let topoNetwork = null;
+
+async function loadTopology() {
+  const [status, nodes, neighbours, routes] = await Promise.allSettled([
+    apiFetch('/status'),
+    apiFetch('/nodes'),
+    apiFetch('/neighbours'),
+    apiFetch('/routes'),
+  ]);
+
+  if (nodes.status !== 'fulfilled') return;
+  const myId = status.status === 'fulfilled' ? status.value.node_id : null;
+
+  // Build vis.js datasets
+  const nodeIds = new Set();
+  const edgeSet = new Set();
+  const visNodes = [];
+  const visEdges = [];
+
+  // Add all known nodes
+  for (const n of nodes.value) {
+    nodeIds.add(n.id);
+    const isSelf = n.id === myId;
+    visNodes.push({
+      id: n.id,
+      label: n.id.length > 12 ? n.id.substring(0, 12) + '…' : n.id,
+      title: n.id + '\n' + (n.is_router ? 'Router' : 'Client') +
+             (isSelf ? ' (this node)' : '') +
+             '\nAddresses: ' + ((n.addresses || []).join(', ') || 'none'),
+      color: {
+        background: isSelf ? '#1a6e2e' : (n.is_router ? '#6e5a1a' : '#2a3a4e'),
+        border: isSelf ? '#3fb950' : (n.is_router ? '#e5a00d' : '#4a6a8a'),
+        highlight: {
+          background: isSelf ? '#238c3c' : (n.is_router ? '#8a7020' : '#3a4a5e'),
+          border: isSelf ? '#5fd070' : (n.is_router ? '#f0b830' : '#5a7a9a'),
+        },
+        hover: {
+          background: isSelf ? '#238c3c' : (n.is_router ? '#8a7020' : '#3a4a5e'),
+          border: isSelf ? '#5fd070' : (n.is_router ? '#f0b830' : '#5a7a9a'),
+        },
+      },
+      font: { color: '#c9d1d9', size: 13 },
+      shape: isSelf ? 'diamond' : (n.is_router ? 'dot' : 'triangle'),
+      size: isSelf ? 22 : (n.is_router ? 18 : 14),
+      borderWidth: isSelf ? 3 : 2,
+    });
+  }
+
+  // Add edges from neighbours
+  if (neighbours.status === 'fulfilled') {
+    for (const nb of neighbours.value) {
+      const edgeKey = myId + '-' + nb.id;
+      const revKey = nb.id + '-' + myId;
+      if (!edgeSet.has(edgeKey) && !edgeSet.has(revKey)) {
+        edgeSet.add(edgeKey);
+        const bestMetric = nb.best_metric || 0;
+        const activeEps = (nb.endpoints || []).filter(e => e.active).length;
+        visEdges.push({
+          from: myId,
+          to: nb.id,
+          label: bestMetric > 0 ? 'metric ' + bestMetric : '',
+          title: 'Metric: ' + bestMetric +
+                 '\nEndpoints: ' + (nb.endpoints ? nb.endpoints.length : 0) +
+                 ' (active: ' + activeEps + ')' +
+                 '\nRoutes: ' + (nb.routes ? nb.routes.length : 0),
+          color: { color: 'rgba(229,160,13,0.4)', highlight: '#e5a00d', hover: '#e5a00d' },
+          font: { color: '#8b949e', size: 11, strokeWidth: 0 },
+          width: bestMetric > 0 ? Math.max(1, 4 - Math.floor(bestMetric / 100)) : 1,
+          smooth: { type: 'continuous' },
+        });
+      }
+    }
+  }
+
+  // Add inferred edges from routes (nexthop connections that aren't direct neighbours)
+  if (routes.status === 'fulfilled') {
+    for (const r of routes.value) {
+      if (!nodeIds.has(r.next_hop)) {
+        // Nexthop node not in our known list, add it as a ghost node
+        nodeIds.add(r.next_hop);
+        visNodes.push({
+          id: r.next_hop,
+          label: r.next_hop.length > 12 ? r.next_hop.substring(0, 12) + '…' : r.next_hop,
+          title: r.next_hop + '\n(inferred from route table)',
+          color: { background: '#2a2a2a', border: '#555', highlight: { background: '#3a3a3a', border: '#777' }, hover: { background: '#3a3a3a', border: '#777' } },
+          font: { color: '#666', size: 11 },
+          shape: 'dot',
+          size: 10,
+          borderWidth: 1,
+          borderWidthSelected: 2,
+        });
+        // Edge from nexthop to the prefix's router
+        if (r.next_hop !== r.router_id && nodeIds.has(r.router_id)) {
+          const eKey = r.next_hop + '-' + r.router_id;
+          const eRev = r.router_id + '-' + r.next_hop;
+          if (!edgeSet.has(eKey) && !edgeSet.has(eRev)) {
+            edgeSet.add(eKey);
+            visEdges.push({
+              from: r.next_hop,
+              to: r.router_id,
+              label: 'via',
+              dashes: true,
+              color: { color: 'rgba(100,100,100,0.25)', highlight: '#888', hover: '#888' },
+              font: { color: '#555', size: 10, strokeWidth: 0 },
+              width: 1,
+              smooth: { type: 'continuous' },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Render with vis.js
+  const container = document.getElementById('topology-canvas');
+  const data = { nodes: visNodes, edges: visEdges };
+
+  const options = {
+    physics: {
+      enabled: true,
+      barnesHut: {
+        gravitationalConstant: -3000,
+        centralGravity: 0.3,
+        springLength: 150,
+        springConstant: 0.04,
+        damping: 0.09,
+      },
+      stabilization: { iterations: 150 },
+    },
+    interaction: {
+      hover: true,
+      tooltipDelay: 150,
+      navigationButtons: true,
+      keyboard: true,
+    },
+    nodes: {
+      shadow: { enabled: true, color: 'rgba(0,0,0,0.3)', size: 8 },
+    },
+    edges: {
+      shadow: { enabled: false },
+    },
+  };
+
+  if (topoNetwork) {
+    topoNetwork.setData(data);
+  } else {
+    topoNetwork = new vis.Network(container, data, options);
   }
 }
 

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -104,13 +104,32 @@ async function loadDashboard() {
 let topoNetwork = null;
 
 async function loadTopology() {
+  const btn = document.getElementById('btn-topo-refresh');
+  const status = document.getElementById('topo-status');
+  btn.disabled = true;
+  btn.setAttribute('aria-busy', 'true');
+  status.textContent = 'loading…';
+
   try {
     const topo = await apiFetch('/topology');
+    const canvas = document.getElementById('topology-canvas');
+    canvas.classList.remove('topo-fade-in');
+    void canvas.offsetWidth; // force reflow
+    canvas.classList.add('topo-fade-in');
     renderTopology(topo);
+    const nodeCount = (topo.nodes || []).length;
+    const edgeCount = (topo.edges || []).length;
+    status.textContent = nodeCount + ' nodes, ' + edgeCount + ' links';
   } catch (err) {
+    status.textContent = '✗ ' + err.message;
     console.error('Failed to load topology:', err);
   }
+
+  btn.disabled = false;
+  btn.removeAttribute('aria-busy');
 }
+
+document.getElementById('btn-topo-refresh').addEventListener('click', loadTopology);
 
 function renderTopology(topo) {
   const nodes = (topo.nodes || []);
@@ -431,7 +450,7 @@ let refreshTimer = null;
 function startAutoRefresh() {
   stopAutoRefresh();
   refreshTimer = setInterval(() => {
-    if (currentPage !== 'log') {
+    if (currentPage !== 'log' && currentPage !== 'topology') {
       loadPage(currentPage);
     }
   }, 10000); // every 10s

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -1,0 +1,359 @@
+// nylon Web UI — app.js
+// Zero-dependency SPA with client-side routing
+
+const API = '/api/v1';
+let currentPage = 'dashboard';
+let ws = null;
+
+// --- Navigation ---
+
+document.querySelectorAll('.nav-link').forEach(link => {
+  link.addEventListener('click', e => {
+    e.preventDefault();
+    navigateTo(link.dataset.page);
+  });
+});
+
+function navigateTo(page) {
+  currentPage = page;
+  document.querySelectorAll('.page').forEach(p => p.hidden = true);
+  const target = document.getElementById('page-' + page);
+  if (target) target.hidden = false;
+  document.querySelectorAll('.nav-link').forEach(l => {
+    l.classList.toggle('active', l.dataset.page === page);
+  });
+  loadPage(page);
+}
+
+// --- API helpers ---
+
+async function apiFetch(endpoint) {
+  const resp = await fetch(API + endpoint);
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({ error: resp.statusText }));
+    throw new Error(err.error || resp.statusText);
+  }
+  return resp.json();
+}
+
+async function apiPost(endpoint) {
+  const resp = await fetch(API + endpoint, { method: 'POST' });
+  return resp.json();
+}
+
+// --- Data loading ---
+
+async function loadPage(page) {
+  try {
+    switch (page) {
+      case 'dashboard': await loadDashboard(); break;
+      case 'nodes': await loadNodes(); break;
+      case 'routes': await loadRoutes(); break;
+      case 'neighbours': await loadNeighbours(); break;
+      case 'prefixes': await loadPrefixes(); break;
+      case 'forward': await loadForward(); break;
+      // 'log' page doesn't need data fetch
+    }
+  } catch (err) {
+    console.error('Failed to load page:', page, err);
+  }
+}
+
+// --- Dashboard ---
+
+async function loadDashboard() {
+  const [status, nodes, routes, neighbours, prefixes] = await Promise.allSettled([
+    apiFetch('/status'),
+    apiFetch('/nodes'),
+    apiFetch('/routes'),
+    apiFetch('/neighbours'),
+    apiFetch('/prefixes'),
+  ]);
+
+  // Stats
+  if (status.status === 'fulfilled') {
+    const s = status.value;
+    document.getElementById('stat-node-id').textContent = s.node_id;
+    document.getElementById('stat-role').textContent = s.is_router ? 'Router' : 'Client';
+    document.getElementById('nav-title').textContent = 'nylon · ' + s.node_id.substring(0, 8);
+  }
+
+  document.getElementById('stat-routes').textContent =
+    routes.status === 'fulfilled' ? routes.value.length : '—';
+  document.getElementById('stat-neighbours').textContent =
+    neighbours.status === 'fulfilled' ? neighbours.value.length : '—';
+  document.getElementById('stat-prefixes').textContent =
+    prefixes.status === 'fulfilled' ? prefixes.value.length : '—';
+
+  // Node table
+  if (nodes.status === 'fulfilled') {
+    const tbody = document.querySelector('#tbl-dashboard-nodes tbody');
+    tbody.innerHTML = nodes.value.map(n => `
+      <tr>
+        <td><code>${esc(n.id)}</code></td>
+        <td>${roleBadge(n.is_router)}</td>
+        <td>${(n.addresses || []).map(a => '<code>' + esc(a) + '</code>').join(', ') || '—'}</td>
+      </tr>
+    `).join('');
+  }
+}
+
+// --- Nodes ---
+
+async function loadNodes() {
+  const nodes = await apiFetch('/nodes');
+  const tbody = document.querySelector('#tbl-nodes tbody');
+  tbody.innerHTML = nodes.map(n => `
+    <tr>
+      <td><code>${esc(n.id)}</code></td>
+      <td>${roleBadge(n.is_router)}</td>
+      <td>${(n.addresses || []).map(a => '<code>' + esc(a) + '</code>').join(', ') || '—'}</td>
+      <td><code title="${esc(n.public_key)}">${esc(n.public_key ? n.public_key.substring(0, 12) + '…' : '—')}</code></td>
+    </tr>
+  `).join('');
+}
+
+// --- Routes ---
+
+async function loadRoutes() {
+  const routes = await apiFetch('/routes');
+  const tbody = document.querySelector('#tbl-routes tbody');
+  tbody.innerHTML = routes.map(r => `
+    <tr>
+      <td><code>${esc(r.prefix)}</code></td>
+      <td><code>${esc(r.next_hop)}</code></td>
+      <td><code>${esc(r.router_id)}</code></td>
+      <td>${r.seqno}</td>
+      <td>${r.metric}</td>
+      <td>${esc(r.expires_at || '—')}</td>
+    </tr>
+  `).join('');
+}
+
+// --- Neighbours ---
+
+async function loadNeighbours() {
+  const neighbours = await apiFetch('/neighbours');
+  const container = document.getElementById('neighbour-cards');
+  container.innerHTML = neighbours.map(n => `
+    <article class="neigh-card">
+      <details open>
+        <summary>
+          <code>${esc(n.id)}</code>
+          ${n.best_metric > 0 ? `<span class="badge active">metric ${n.best_metric}</span>` : ''}
+        </summary>
+        <div class="neigh-meta">
+          <span>Endpoints: <strong>${n.endpoints ? n.endpoints.length : 0}</strong></span>
+          <span>Routes: <strong>${n.routes ? n.routes.length : 0}</strong></span>
+        </div>
+        ${n.endpoints && n.endpoints.length > 0 ? `
+        <table class="endpoint-list">
+          <thead><tr><th>Address</th><th>Resolved</th><th>Active</th><th>Metric</th><th>Remote</th></tr></thead>
+          <tbody>
+            ${n.endpoints.map(ep => `
+              <tr>
+                <td><code>${esc(ep.address)}</code></td>
+                <td><code>${esc(ep.resolved || '—')}</code></td>
+                <td>${ep.active ? '✓' : '✗'}</td>
+                <td>${ep.metric}</td>
+                <td>${ep.is_remote ? '✓' : '✗'}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+        ` : '<p><small>No endpoints</small></p>'}
+        ${n.routes && n.routes.length > 0 ? `
+        <footer><small>Routes: ${n.routes.map(r => '<code>' + esc(r) + '</code>').join(', ')}</small></footer>
+        ` : ''}
+      </details>
+    </article>
+  `).join('');
+}
+
+// --- Prefixes ---
+
+async function loadPrefixes() {
+  const prefixes = await apiFetch('/prefixes');
+  const tbody = document.querySelector('#tbl-prefixes tbody');
+  tbody.innerHTML = prefixes.map(p => `
+    <tr>
+      <td><code>${esc(p.prefix)}</code></td>
+      <td><code>${esc(p.router_id)}</code></td>
+      <td>${p.metric}</td>
+      <td><span class="badge ${p.type}">${esc(p.type)}</span></td>
+      <td>${esc(p.expires_at || '—')}</td>
+    </tr>
+  `).join('');
+}
+
+// --- Forward ---
+
+async function loadForward() {
+  const entries = await apiFetch('/forward');
+  const tbody = document.querySelector('#tbl-forward tbody');
+  tbody.innerHTML = entries.map(e => `
+    <tr>
+      <td><code>${esc(e.prefix)}</code></td>
+      <td><code>${esc(e.next_hop)}</code></td>
+    </tr>
+  `).join('');
+}
+
+// --- WebSocket Live Log ---
+
+const btnConnect = document.getElementById('btn-log-connect');
+const btnClear = document.getElementById('btn-log-clear');
+const logOutput = document.getElementById('log-output');
+const wsStatus = document.getElementById('ws-status');
+
+btnConnect.addEventListener('click', () => {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.close();
+  } else {
+    connectWS();
+  }
+});
+
+btnClear.addEventListener('click', () => {
+  logOutput.innerHTML = '';
+});
+
+function connectWS() {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url = proto + '//' + location.host + API + '/ws';
+  wsStatus.textContent = 'connecting';
+  wsStatus.className = 'ws-status connecting';
+  btnConnect.textContent = 'Connecting…';
+
+  ws = new WebSocket(url, ['ws']);
+
+  ws.onopen = () => {
+    wsStatus.textContent = 'connected';
+    wsStatus.className = 'ws-status connected';
+    btnConnect.textContent = 'Disconnect';
+    appendLog('--- connected ---', 'system');
+  };
+
+  ws.onmessage = (evt) => {
+    try {
+      const msg = JSON.parse(evt.data);
+      if (msg.type === 'trace' && msg.data) {
+        const data = typeof msg.data === 'string' ? JSON.parse(msg.data) : msg.data;
+        appendLog(data.message || JSON.stringify(data), 'trace', data.ts);
+      } else if (msg.type === 'pong') {
+        appendLog('pong', 'system');
+      } else if (msg.type === 'error') {
+        const data = typeof msg.data === 'string' ? JSON.parse(msg.data) : msg.data;
+        appendLog('error: ' + (data.error || JSON.stringify(data)), 'error');
+      } else {
+        appendLog(JSON.stringify(msg), 'unknown');
+      }
+    } catch {
+      appendLog(evt.data, 'raw');
+    }
+  };
+
+  ws.onclose = () => {
+    wsStatus.textContent = 'disconnected';
+    wsStatus.className = 'ws-status disconnected';
+    btnConnect.textContent = 'Connect';
+    appendLog('--- disconnected ---', 'system');
+  };
+
+  ws.onerror = () => {
+    appendLog('--- connection error ---', 'error');
+  };
+}
+
+function appendLog(text, type, ts) {
+  const line = document.createElement('div');
+  line.className = 'log-line';
+  const time = ts ? new Date(ts).toLocaleTimeString() : new Date().toLocaleTimeString();
+  line.innerHTML = `<span class="log-ts">${esc(time)}</span>${esc(text)}`;
+  logOutput.appendChild(line);
+  // Auto-scroll
+  logOutput.scrollTop = logOutput.scrollHeight;
+  // Keep max 500 lines
+  while (logOutput.children.length > 500) {
+    logOutput.removeChild(logOutput.firstChild);
+  }
+}
+
+// --- Actions ---
+
+document.getElementById('btn-reload').addEventListener('click', async () => {
+  await doAction('/reload', 'btn-reload');
+  // Reload will restart the node, so refresh after delay
+  setTimeout(() => loadDashboard(), 3000);
+});
+
+document.getElementById('btn-flush').addEventListener('click', async () => {
+  await doAction('/flush_routes', 'btn-flush');
+});
+
+async function doAction(endpoint, btnId) {
+  const result = document.getElementById('action-result');
+  const btn = document.getElementById(btnId);
+  btn.disabled = true;
+  btn.setAttribute('aria-busy', 'true');
+  result.hidden = true;
+
+  try {
+    const resp = await apiPost(endpoint);
+    if (resp.success) {
+      result.textContent = '✓ ' + (resp.message || 'OK');
+      result.className = 'success';
+    } else {
+      result.textContent = '✗ ' + (resp.message || resp.error || 'Unknown error');
+      result.className = 'error';
+    }
+  } catch (err) {
+    result.textContent = '✗ ' + err.message;
+    result.className = 'error';
+  }
+
+  result.hidden = false;
+  btn.disabled = false;
+  btn.removeAttribute('aria-busy');
+  setTimeout(() => { result.hidden = true; }, 5000);
+}
+
+// --- Helpers ---
+
+function esc(s) {
+  if (s == null) return '';
+  const div = document.createElement('div');
+  div.textContent = String(s);
+  return div.innerHTML;
+}
+
+function roleBadge(isRouter) {
+  return isRouter
+    ? '<span class="badge router">Router</span>'
+    : '<span class="badge client">Client</span>';
+}
+
+// --- Auto-refresh ---
+
+let refreshTimer = null;
+
+function startAutoRefresh() {
+  stopAutoRefresh();
+  refreshTimer = setInterval(() => {
+    if (currentPage !== 'log') {
+      loadPage(currentPage);
+    }
+  }, 10000); // every 10s
+}
+
+function stopAutoRefresh() {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+// --- Init ---
+
+loadDashboard();
+startAutoRefresh();

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -104,32 +104,25 @@ async function loadDashboard() {
 let topoNetwork = null;
 
 async function loadTopology() {
-  const [status, nodes, neighbours, routes] = await Promise.allSettled([
-    apiFetch('/status'),
-    apiFetch('/nodes'),
-    apiFetch('/neighbours'),
-    apiFetch('/routes'),
-  ]);
+  try {
+    const topo = await apiFetch('/topology');
+    renderTopology(topo);
+  } catch (err) {
+    console.error('Failed to load topology:', err);
+  }
+}
 
-  if (nodes.status !== 'fulfilled') return;
-  const myId = status.status === 'fulfilled' ? status.value.node_id : null;
+function renderTopology(topo) {
+  const nodes = (topo.nodes || []);
+  const edges = (topo.edges || []);
 
-  // Build vis.js datasets
-  const nodeIds = new Set();
-  const edgeSet = new Set();
-  const visNodes = [];
-  const visEdges = [];
-
-  // Add all known nodes
-  for (const n of nodes.value) {
-    nodeIds.add(n.id);
-    const isSelf = n.id === myId;
-    visNodes.push({
+  const visNodes = nodes.map(n => {
+    const isSelf = n.is_self;
+    return {
       id: n.id,
       label: n.id.length > 12 ? n.id.substring(0, 12) + '…' : n.id,
       title: n.id + '\n' + (n.is_router ? 'Router' : 'Client') +
-             (isSelf ? ' (this node)' : '') +
-             '\nAddresses: ' + ((n.addresses || []).join(', ') || 'none'),
+             (isSelf ? ' (this node)' : ''),
       color: {
         background: isSelf ? '#1a6e2e' : (n.is_router ? '#6e5a1a' : '#2a3a4e'),
         border: isSelf ? '#3fb950' : (n.is_router ? '#e5a00d' : '#4a6a8a'),
@@ -146,75 +139,20 @@ async function loadTopology() {
       shape: isSelf ? 'diamond' : (n.is_router ? 'dot' : 'triangle'),
       size: isSelf ? 22 : (n.is_router ? 18 : 14),
       borderWidth: isSelf ? 3 : 2,
-    });
-  }
+    };
+  });
 
-  // Add edges from neighbours
-  if (neighbours.status === 'fulfilled') {
-    for (const nb of neighbours.value) {
-      const edgeKey = myId + '-' + nb.id;
-      const revKey = nb.id + '-' + myId;
-      if (!edgeSet.has(edgeKey) && !edgeSet.has(revKey)) {
-        edgeSet.add(edgeKey);
-        const bestMetric = nb.best_metric || 0;
-        const activeEps = (nb.endpoints || []).filter(e => e.active).length;
-        visEdges.push({
-          from: myId,
-          to: nb.id,
-          label: bestMetric > 0 ? 'metric ' + bestMetric : '',
-          title: 'Metric: ' + bestMetric +
-                 '\nEndpoints: ' + (nb.endpoints ? nb.endpoints.length : 0) +
-                 ' (active: ' + activeEps + ')' +
-                 '\nRoutes: ' + (nb.routes ? nb.routes.length : 0),
-          color: { color: 'rgba(229,160,13,0.4)', highlight: '#e5a00d', hover: '#e5a00d' },
-          font: { color: '#8b949e', size: 11, strokeWidth: 0 },
-          width: bestMetric > 0 ? Math.max(1, 4 - Math.floor(bestMetric / 100)) : 1,
-          smooth: { type: 'continuous' },
-        });
-      }
-    }
-  }
+  const visEdges = edges.map(e => ({
+    from: e.from,
+    to: e.to,
+    label: e.metric > 0 ? 'metric ' + e.metric : '',
+    title: 'Metric: ' + e.metric,
+    color: { color: 'rgba(229,160,13,0.5)', highlight: '#e5a00d', hover: '#e5a00d' },
+    font: { color: '#8b949e', size: 11, strokeWidth: 0 },
+    width: e.metric > 0 ? Math.max(1, 4 - Math.floor(e.metric / 100)) : 1,
+    smooth: { type: 'continuous' },
+  }));
 
-  // Add inferred edges from routes (nexthop connections that aren't direct neighbours)
-  if (routes.status === 'fulfilled') {
-    for (const r of routes.value) {
-      if (!nodeIds.has(r.next_hop)) {
-        // Nexthop node not in our known list, add it as a ghost node
-        nodeIds.add(r.next_hop);
-        visNodes.push({
-          id: r.next_hop,
-          label: r.next_hop.length > 12 ? r.next_hop.substring(0, 12) + '…' : r.next_hop,
-          title: r.next_hop + '\n(inferred from route table)',
-          color: { background: '#2a2a2a', border: '#555', highlight: { background: '#3a3a3a', border: '#777' }, hover: { background: '#3a3a3a', border: '#777' } },
-          font: { color: '#666', size: 11 },
-          shape: 'dot',
-          size: 10,
-          borderWidth: 1,
-          borderWidthSelected: 2,
-        });
-        // Edge from nexthop to the prefix's router
-        if (r.next_hop !== r.router_id && nodeIds.has(r.router_id)) {
-          const eKey = r.next_hop + '-' + r.router_id;
-          const eRev = r.router_id + '-' + r.next_hop;
-          if (!edgeSet.has(eKey) && !edgeSet.has(eRev)) {
-            edgeSet.add(eKey);
-            visEdges.push({
-              from: r.next_hop,
-              to: r.router_id,
-              label: 'via',
-              dashes: true,
-              color: { color: 'rgba(100,100,100,0.25)', highlight: '#888', hover: '#888' },
-              font: { color: '#555', size: 10, strokeWidth: 0 },
-              width: 1,
-              smooth: { type: 'continuous' },
-            });
-          }
-        }
-      }
-    }
-  }
-
-  // Render with vis.js
   const container = document.getElementById('topology-canvas');
   const data = { nodes: visNodes, edges: visEdges };
 

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -88,6 +88,10 @@
         <h2>Topology</h2>
         <p>Mesh network graph — drag nodes to rearrange, scroll to zoom</p>
       </hgroup>
+      <div class="topo-toolbar">
+        <button id="btn-topo-refresh" class="outline secondary">↻ Refresh</button>
+        <small id="topo-status"></small>
+      </div>
       <article>
         <div class="topology-legend">
           <span class="legend-item"><span class="legend-dot router-dot"></span> Router</span>

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nylon</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <link rel="stylesheet" href="/ui/style.css">
+</head>
+<body>
+  <nav class="container-fluid">
+    <ul>
+      <li><strong id="nav-title">nylon</strong></li>
+    </ul>
+    <ul>
+      <li><a href="#" data-page="dashboard" class="nav-link active">Dashboard</a></li>
+      <li><a href="#" data-page="nodes" class="nav-link">Nodes</a></li>
+      <li><a href="#" data-page="routes" class="nav-link">Routes</a></li>
+      <li><a href="#" data-page="neighbours" class="nav-link">Neighbours</a></li>
+      <li><a href="#" data-page="prefixes" class="nav-link">Prefixes</a></li>
+      <li><a href="#" data-page="forward" class="nav-link">Forward</a></li>
+      <li><a href="#" data-page="log" class="nav-link">Live Log</a></li>
+    </ul>
+  </nav>
+
+  <main class="container-fluid">
+    <!-- Dashboard -->
+    <section id="page-dashboard" class="page">
+      <hgroup>
+        <h2>Dashboard</h2>
+        <p>Mesh network overview</p>
+      </hgroup>
+      <div class="grid">
+        <div>
+          <article class="stat-card">
+            <header>Node ID</header>
+            <h3 id="stat-node-id">—</h3>
+            <footer id="stat-role">—</footer>
+          </article>
+        </div>
+        <div>
+          <article class="stat-card">
+            <header>Routes</header>
+            <h3 id="stat-routes">—</h3>
+          </article>
+        </div>
+        <div>
+          <article class="stat-card">
+            <header>Neighbours</header>
+            <h3 id="stat-neighbours">—</h3>
+          </article>
+        </div>
+        <div>
+          <article class="stat-card">
+            <header>Prefixes</header>
+            <h3 id="stat-prefixes">—</h3>
+          </article>
+        </div>
+      </div>
+      <div class="grid">
+        <div>
+          <article>
+            <header>Nodes</header>
+            <table id="tbl-dashboard-nodes">
+              <thead><tr><th>ID</th><th>Role</th><th>Addresses</th></tr></thead>
+              <tbody></tbody>
+            </table>
+          </article>
+        </div>
+        <div>
+          <article>
+            <header>Actions</header>
+            <div class="grid">
+              <button id="btn-reload" class="contrast outline" data-tooltip="Reload configuration and restart">Reload Config</button>
+              <button id="btn-flush" class="secondary outline" data-tooltip="Send full route table update to all neighbours">Flush Routes</button>
+            </div>
+            <div id="action-result" role="alert" hidden></div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Nodes -->
+    <section id="page-nodes" class="page" hidden>
+      <hgroup>
+        <h2>Nodes</h2>
+        <p>All mesh participants</p>
+      </hgroup>
+      <article>
+        <table id="tbl-nodes">
+          <thead><tr><th>ID</th><th>Role</th><th>Addresses</th><th>Public Key</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </section>
+
+    <!-- Routes -->
+    <section id="page-routes" class="page" hidden>
+      <hgroup>
+        <h2>Routes</h2>
+        <p>Babel routing table</p>
+      </hgroup>
+      <article>
+        <table id="tbl-routes">
+          <thead><tr><th>Prefix</th><th>Next Hop</th><th>Router ID</th><th>SeqNo</th><th>Metric</th><th>Expires</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </section>
+
+    <!-- Neighbours -->
+    <section id="page-neighbours" class="page" hidden>
+      <hgroup>
+        <h2>Neighbours</h2>
+        <p>Direct peer connections</p>
+      </hgroup>
+      <div id="neighbour-cards"></div>
+    </section>
+
+    <!-- Prefixes -->
+    <section id="page-prefixes" class="page" hidden>
+      <hgroup>
+        <h2>Prefixes</h2>
+        <p>Advertised network prefixes</p>
+      </hgroup>
+      <article>
+        <table id="tbl-prefixes">
+          <thead><tr><th>Prefix</th><th>Router ID</th><th>Metric</th><th>Type</th><th>Expires</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </section>
+
+    <!-- Forward -->
+    <section id="page-forward" class="page" hidden>
+      <hgroup>
+        <h2>Forwarding Table</h2>
+        <p>Kernel forwarding entries</p>
+      </hgroup>
+      <article>
+        <table id="tbl-forward">
+          <thead><tr><th>Prefix</th><th>Next Hop</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </section>
+
+    <!-- Live Log -->
+    <section id="page-log" class="page" hidden>
+      <hgroup>
+        <h2>Live Log</h2>
+        <p>Real-time trace events via WebSocket</p>
+      </hgroup>
+      <article>
+        <div class="log-toolbar">
+          <button id="btn-log-connect" class="secondary outline">Connect</button>
+          <button id="btn-log-clear" class="contrast outline">Clear</button>
+          <span id="ws-status" class="ws-status disconnected">disconnected</span>
+        </div>
+        <div id="log-output" class="log-output"></div>
+      </article>
+    </section>
+  </main>
+
+  <script src="/ui/app.js"></script>
+</body>
+</html>

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -6,6 +6,7 @@
   <title>nylon</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <link rel="stylesheet" href="/ui/style.css">
+  <script type="text/javascript" src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"></script>
 </head>
 <body>
   <nav class="container-fluid">
@@ -14,6 +15,7 @@
     </ul>
     <ul>
       <li><a href="#" data-page="dashboard" class="nav-link active">Dashboard</a></li>
+      <li><a href="#" data-page="topology" class="nav-link">Topology</a></li>
       <li><a href="#" data-page="nodes" class="nav-link">Nodes</a></li>
       <li><a href="#" data-page="routes" class="nav-link">Routes</a></li>
       <li><a href="#" data-page="neighbours" class="nav-link">Neighbours</a></li>
@@ -78,6 +80,22 @@
           </article>
         </div>
       </div>
+    </section>
+
+    <!-- Topology -->
+    <section id="page-topology" class="page" hidden>
+      <hgroup>
+        <h2>Topology</h2>
+        <p>Mesh network graph — drag nodes to rearrange, scroll to zoom</p>
+      </hgroup>
+      <article>
+        <div class="topology-legend">
+          <span class="legend-item"><span class="legend-dot router-dot"></span> Router</span>
+          <span class="legend-item"><span class="legend-dot client-dot"></span> Client</span>
+          <span class="legend-item"><span class="legend-dot self-dot"></span> This Node</span>
+        </div>
+        <div id="topology-canvas"></div>
+      </article>
     </section>
 
     <!-- Nodes -->

--- a/core/ui/style.css
+++ b/core/ui/style.css
@@ -1,0 +1,209 @@
+/* nylon Web UI styles */
+
+:root {
+  --nylon-accent: #e5a00d;
+  --nylon-bg-card: #18191a;
+  --log-bg: #111213;
+  --log-text: #c9d1d9;
+}
+
+[data-theme="dark"] {
+  --nylon-accent: #e5a00d;
+}
+
+/* Navigation */
+nav .nav-link {
+  text-decoration: none;
+  color: var(--pico-muted-color);
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--pico-border-radius);
+  transition: color 0.2s, background 0.2s;
+}
+
+nav .nav-link:hover,
+nav .nav-link.active {
+  color: var(--nylon-accent);
+  background: rgba(229, 160, 13, 0.1);
+}
+
+/* Stat cards */
+.stat-card header {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--pico-muted-color);
+  margin-bottom: 0.25rem;
+}
+
+.stat-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--nylon-accent);
+  word-break: break-all;
+}
+
+.stat-card footer {
+  font-size: 0.85rem;
+  color: var(--pico-muted-color);
+}
+
+/* Neighbour cards */
+.neigh-card {
+  margin-bottom: 1rem;
+}
+
+.neigh-card summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.neigh-card .neigh-meta {
+  display: flex;
+  gap: 1.5rem;
+  margin: 0.5rem 0;
+  flex-wrap: wrap;
+}
+
+.neigh-card .neigh-meta span {
+  font-size: 0.85rem;
+}
+
+.neigh-card .endpoint-list {
+  font-size: 0.85rem;
+}
+
+.neigh-card .endpoint-list td {
+  padding: 0.2rem 0.5rem;
+}
+
+/* Action result */
+#action-result {
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--pico-border-radius);
+  font-size: 0.9rem;
+}
+
+#action-result.success {
+  background: rgba(46, 160, 67, 0.15);
+  color: #3fb950;
+  border: 1px solid rgba(46, 160, 67, 0.3);
+}
+
+#action-result.error {
+  background: rgba(248, 81, 73, 0.15);
+  color: #f85149;
+  border: 1px solid rgba(248, 81, 73, 0.3);
+}
+
+/* Log output */
+.log-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.ws-status {
+  font-size: 0.8rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ws-status.connected {
+  background: rgba(46, 160, 67, 0.2);
+  color: #3fb950;
+}
+
+.ws-status.disconnected {
+  background: rgba(248, 81, 73, 0.2);
+  color: #f85149;
+}
+
+.ws-status.connecting {
+  background: rgba(229, 160, 13, 0.2);
+  color: var(--nylon-accent);
+}
+
+.log-output {
+  background: var(--log-bg);
+  color: var(--log-text);
+  font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  padding: 0.75rem;
+  border-radius: var(--pico-border-radius);
+  max-height: 70vh;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-output .log-line {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 0.15rem 0;
+}
+
+.log-output .log-ts {
+  color: var(--pico-muted-color);
+  margin-right: 0.5rem;
+}
+
+/* Tables */
+table tbody tr:hover {
+  background: rgba(229, 160, 13, 0.05);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Page transitions */
+.page {
+  animation: fadeIn 0.2s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Badge */
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.badge.router {
+  background: rgba(229, 160, 13, 0.2);
+  color: var(--nylon-accent);
+}
+
+.badge.client {
+  background: rgba(110, 118, 129, 0.2);
+  color: #8b949e;
+}
+
+.badge.active {
+  background: rgba(46, 160, 67, 0.2);
+  color: #3fb950;
+}
+
+.badge.passive {
+  background: rgba(110, 118, 129, 0.2);
+  color: #8b949e;
+}

--- a/core/ui/style.css
+++ b/core/ui/style.css
@@ -201,6 +201,26 @@ table tbody tr:hover {
   background: #111213;
 }
 
+#topology-canvas.topo-fade-in {
+  animation: topoFadeIn 0.35s ease-out;
+}
+
+@keyframes topoFadeIn {
+  from { opacity: 0.2; }
+  to   { opacity: 1; }
+}
+
+.topo-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.topo-toolbar small {
+  color: var(--pico-muted-color);
+}
+
 /* Page transitions */
 .page {
   animation: fadeIn 0.2s ease-in;

--- a/core/ui/style.css
+++ b/core/ui/style.css
@@ -167,6 +167,40 @@ table tbody tr:hover {
   }
 }
 
+/* Topology */
+.topology-legend {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.legend-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.legend-dot.router-dot { background: #e5a00d; }
+.legend-dot.client-dot { background: #4a6a8a; }
+.legend-dot.self-dot   { background: #3fb950; }
+
+#topology-canvas {
+  width: 100%;
+  height: 65vh;
+  min-height: 400px;
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: var(--pico-border-radius);
+  background: #111213;
+}
+
 /* Page transitions */
 .page {
   animation: fadeIn 0.2s ease-in;

--- a/example/sample-node.yaml
+++ b/example/sample-node.yaml
@@ -5,6 +5,7 @@ port: 57175 # Default: 57175 - UDP port that Nylon listens on
 # the following are optional
 use_system_routing: false # Default: false - all packets from peers will come out of the TUN interface
 no_net_configure: false # Default: false - do not configure system networking at all
+fwmark: 0 # Default: 0 (uses port value) - Linux fwmark for Nylon's WireGuard socket; enables policy routing that prevents loops when running alongside Tailscale or other VPNs
 log_path: "" # Default: "" - If set, Nylon will log to this file
 interface_name: "" # Default: "" - If set, Nylon will use this interface name instead of the default "nylon" or utunx on macOS
 dns_resolvers: [] # Default: [] - If set (e.g ["1.1.1.1:53"]), nylon will use these DNS resolvers for its own queries

--- a/state/config.go
+++ b/state/config.go
@@ -58,6 +58,7 @@ type LocalCfg struct {
 	DnsResolvers     []string              `yaml:"dns_resolvers,omitempty"`      // dns resolvers used by nylon, currently only for config repo
 	InterfaceName    string                `yaml:"interface_name,omitempty"`     // the name of the nylon interface
 	LogPath          string                `yaml:"log_path,omitempty"`           // if not empty, nylon will write to this file
+	Fwmark           uint32                `yaml:"fwmark,omitempty"`             // firewall mark for policy routing on Linux (0 = use port value); prevents routing loops when running alongside other VPNs (e.g. Tailscale)
 	UnexcludeIPs     []netip.Prefix        `yaml:"unexclude_ips,omitempty"`      // split tunnel, subtracts from centrally excluded ip ranges
 	ExcludeIPs       []netip.Prefix        `yaml:"exclude_ips,omitempty"`        // split tunnel, adds to the centrally excluded ip ranges
 	PreUp            []string              `yaml:"pre_up,omitempty"`             // a list of commands executed in order before the nylon interface is brought up


### PR DESCRIPTION
## Summary
<img width="1311" height="651" alt="截屏2026-04-12 09 25 35" src="https://github.com/user-attachments/assets/04da8152-9ab2-4d35-9997-85d58e522f97" />

Adds a full-featured control plane module to nylon with a REST API, WebSocket real-time log streaming, and an embedded web UI (SPA) for mesh network monitoring and management.

## Phases

### Phase 1 — Read-only REST API
- `/api/v1/status` — node identity and role
- `/api/v1/nodes` — all mesh participants
- `/api/v1/routes` — Babel route table
- `/api/v1/neighbours` — neighbour links with endpoint/metric details
- `/api/v1/prefixes` — advertised prefixes
- `/api/v1/forward` — kernel forwarding table
- `/api/v1/sysroutes` — system route table

### Phase 2 — Write Operations & WebSocket
- `POST /api/v1/reload` — trigger config reload
- `POST /api/v1/flush_routes` — flush Babel routes
- `WS /api/v1/ws` — real-time packet trace stream
- Write ops use the existing Dispatch mechanism to safely mutate shared state

### Phase 3 — Embedded Web UI
- Zero build dependencies: Vanilla JS + Pico CSS (CDN)
- `go:embed` for static assets, no external file serving needed
- SPA with client-side routing, 8 pages:
  - **Dashboard** — node stats, routes, neighbours, prefix counts
  - **Topology** — interactive mesh graph (vis.js) with multi-hop aggregation
  - **Nodes, Routes, Neighbours, Prefixes, Forward** — tabular views
  - **Live Log** — WebSocket trace viewer
- 10s auto-refresh (topology is manual-only)
- Actions: Reload, Flush Routes

### Topology Aggregation
- Control plane listens on both `127.0.0.1:58175` and mesh prefix address (e.g. `10.114.154.11:58175`)
- Mesh listener retries binding for up to 30s (WG interface may not exist at Init time)
- `/api/v1/topology` performs BFS across mesh: queries each node's `/status` + `/neighbours` via mesh network, producing a complete `{nodes, edges}` graph
- Edges with infinite metric (4294967295 / Babel infinity) are excluded

## Files Changed
- `core/control_plane.go` (+852) — REST API, WebSocket, topology aggregation, mesh listener
- `core/entrypoint.go` (+1) — register ControlPlane module
- `core/ui/index.html` (+189) — SPA shell
- `core/ui/app.js` (+469) — SPA logic, vis.js topology rendering
- `core/ui/style.css` (+263) — dark theme, topology canvas, animations

## Design Decisions
- **Non-fatal control plane** — if bind fails, nylon continues normally
- **Dispatch for state access** — all reads go through the existing serial dispatch loop, no new locks needed
- **Mesh listener delayed bind** — ControlPlane.Init() runs before Nylon creates the WG interface; goroutine retries every 1s for 30s
