### PR TITLE
fix(core): logic bug relating to RetractedBy

### DIFF
--- a/core/router_algo.go
+++ b/core/router_algo.go
@@ -254,6 +254,9 @@ func HandleAckRetract(s *state.RouterState, r Router, neighId state.NodeId, pref
 		r.RouterEvent(log.EventInconsistentState, "attempted to ack the retraction of a non-existent route", "prefix", prefix)
 		return // route does not exist
 	}
+	if rt.Metric != state.INF {
+		return // retraction ACKs only apply to held routes
+	}
 	if !slices.Contains(rt.RetractedBy, neighId) {
 		rt.RetractedBy = append(rt.RetractedBy, neighId)
 		s.Routes[prefix] = rt // update the route table
@@ -492,9 +495,10 @@ func ComputeRoutes(s *state.RouterState, r Router) {
 
 			oldRoute, exists := newTable[prefix]
 
-			retractedBy := make([]state.NodeId, 0)
-			if exists {
-				retractedBy = oldRoute.RetractedBy
+			//   *  a route with infinite metric (a retracted route) is never
+			//      selected;
+			if totalCost == state.INF {
+				continue // ignored
 			}
 
 			fd := state.FD{
@@ -508,23 +512,19 @@ func ComputeRoutes(s *state.RouterState, r Router) {
 				},
 				Nh:          neigh.Id,
 				ExpireAt:    adv.ExpireAt,
-				RetractedBy: retractedBy,
-			}
-
-			// update the route if it is currently selected
-			if exists && oldRoute.Nh == newRoute.Nh {
-				newTable[prefix] = newRoute
-			}
-
-			//   *  a route with infinite metric (a retracted route) is never
-			//      selected;
-			if totalCost == state.INF {
-				continue // ignored
+				RetractedBy: []state.NodeId{},
 			}
 
 			//   *  an unfeasible route is never selected.
 			if !checkFeasibility(s, adv.PubRoute) {
 				continue // ignored
+			}
+
+			// Refresh the current winner for this recomputation. This keeps a
+			// selected next hop selected even when its metric worsens.
+			if exists && oldRoute.Nh == newRoute.Nh {
+				newTable[prefix] = newRoute
+				continue
 			}
 
 			if !exists {
@@ -579,6 +579,7 @@ func ComputeRoutes(s *state.RouterState, r Router) {
 				r.RouterEvent(log.EventRouteRetracted, "retracted", "prefix", prefix, "old", oldRoute)
 				// Add the retracted route back as INF so it can be held
 				oldRoute.Metric = state.INF
+				oldRoute.RetractedBy = nil
 				newTable[prefix] = oldRoute
 			}
 		}

--- a/core/router_test.go
+++ b/core/router_test.go
@@ -640,6 +640,78 @@ func TestRouter_BackupRouteOverridesHeldRoute(t *testing.T) {
 	assert.Equal(t, uint32(11), rs.Routes[cPrefix].Metric)
 }
 
+func TestRouter_RetractedByClearedWhenHeldRouteRecovers(t *testing.T) {
+	ConfigureConstants()
+	// Topology:
+	// A --(1)-- C
+	// A --(1)-- B --(10)-- C
+	// A --(1)-- D
+	// D keeps the held route alive after B acknowledges the retraction.
+
+	h := &RouterHarness{}
+	cPrefix := nodeToPrefix("C")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C", "D"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	AC := AddLink(rs, NewMockEndpoint("C", 1))
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+	_ = AddLink(rs, NewMockEndpoint("D", 1))
+
+	h.NeighUpdate(rs, "C", "C", cPrefix, 0, 0)
+	h.NeighUpdate(rs, "B", "C", cPrefix, 0, 10)
+	ComputeRoutes(rs, h)
+
+	assert.Equal(t, "C", string(rs.Routes[cPrefix].Nh))
+	assert.Equal(t, uint32(1), rs.Routes[cPrefix].Metric)
+
+	RemoveLink(rs, AC)
+	ComputeRoutes(rs, h)
+	assert.Equal(t, state.INF, rs.Routes[cPrefix].Metric)
+
+	HandleAckRetract(rs, h, "B", cPrefix)
+	assert.Equal(t, []state.NodeId{"B"}, rs.Routes[cPrefix].RetractedBy)
+
+	h.NeighUpdate(rs, "B", "C", cPrefix, 1, 10)
+	ComputeRoutes(rs, h)
+
+	assert.Equal(t, "B", string(rs.Routes[cPrefix].Nh))
+	assert.Equal(t, uint32(11), rs.Routes[cPrefix].Metric)
+	assert.Empty(t, rs.Routes[cPrefix].RetractedBy)
+}
+
+func TestRouter_AckRetractIgnoredForFiniteRoute(t *testing.T) {
+	ConfigureConstants()
+
+	h := &RouterHarness{}
+	cPrefix := nodeToPrefix("C")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	_ = AddLink(rs, NewMockEndpoint("C", 1))
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+
+	h.NeighUpdate(rs, "C", "C", cPrefix, 0, 0)
+	ComputeRoutes(rs, h)
+
+	assert.Equal(t, "C", string(rs.Routes[cPrefix].Nh))
+	assert.Equal(t, uint32(1), rs.Routes[cPrefix].Metric)
+
+	HandleAckRetract(rs, h, "B", cPrefix)
+	assert.Empty(t, rs.Routes[cPrefix].RetractedBy)
+}
+
 func TestRouter5A_GCRoutes(t *testing.T) {
 	ConfigureConstants()
 	state.RouteExpiryTime = -1 // for testing, we want routes to expire immediately


### PR DESCRIPTION
Nylon does not properly track retraction ACK in the following cases:
- the current route is not "held", but receives an ACK
- the current route is retracted by a neighbour, but becomes available again (RetractedBy is not cleared)