### PR TITLE
fix(core): seqno request is too optimistic

### DIFF
--- a/core/router_algo.go
+++ b/core/router_algo.go
@@ -317,11 +317,18 @@ func HandleNeighbourUpdate(s *state.RouterState, r Router, neighId state.NodeId,
 		selRoute, hasSelected := s.Routes[adv.Source.Prefix]
 		isSelected := hasSelected && selRoute.Nh == neighId
 		if !checkFeasibility(s, adv) {
-			isMoreOptimal := hasSelected && ShouldSwitch(selRoute, state.SelRoute{
+			dummy := state.SelRoute{
 				PubRoute: adv,
 				Nh:       neighId,
 				ExpireAt: time.Time{},
-			})
+			}
+			bestEp := n.BestEndpoint()
+			if bestEp != nil {
+				dummy.Metric = AddMetric(dummy.Metric, AddMetric(bestEp.Metric(), state.HopCost))
+			} else {
+				dummy.Metric = state.INF
+			}
+			isMoreOptimal := hasSelected && ShouldSwitch(selRoute, dummy)
 			if isSelected {
 				// 3.8.2.2.  Dealing with Unfeasible Updates
 				//   In order to keep routes from spuriously expiring because they have

--- a/core/router_test.go
+++ b/core/router_test.go
@@ -712,6 +712,48 @@ func TestRouter_AckRetractIgnoredForFiniteRoute(t *testing.T) {
 	assert.Empty(t, rs.Routes[cPrefix].RetractedBy)
 }
 
+func TestRouter_UnfeasibleUpdatePreferenceUsesTotalMetric(t *testing.T) {
+	ConfigureConstants()
+	state.HopCost = 5
+	// Topology:
+	// A --(5, then 20)-- C
+	// A --(5)-- B --(10, then 20)-- C
+	// B's later update is unfeasible and its advertised metric is lower than
+	// the selected total metric, but its total metric through B is worse once
+	// link cost and HopCost are included.
+
+	h := &RouterHarness{}
+	cPrefix := nodeToPrefix("C")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	AC := AddLink(rs, NewMockEndpoint("C", 5))
+	_ = AddLink(rs, NewMockEndpoint("B", 5))
+
+	h.NeighUpdate(rs, "C", "C", cPrefix, 0, 0)
+	h.NeighUpdate(rs, "B", "C", cPrefix, 0, 10)
+	ComputeRoutes(rs, h)
+	assert.Equal(t, "C", string(rs.Routes[cPrefix].Nh))
+	assert.Equal(t, uint32(10), rs.Routes[cPrefix].Metric)
+	h.GetActions()
+
+	AC.metric = 20
+	ComputeRoutes(rs, h)
+	assert.Equal(t, "C", string(rs.Routes[cPrefix].Nh))
+	assert.Equal(t, uint32(25), rs.Routes[cPrefix].Metric)
+	h.GetActions()
+
+	h.NeighUpdate(rs, "B", "C", cPrefix, 0, 20)
+	a := h.GetActions()
+	a.AssertNotContains(t, RequestSeqno("B", state.Source{NodeId: "C", Prefix: cPrefix}, 1, 64))
+}
+
 func TestRouter5A_GCRoutes(t *testing.T) {
 	ConfigureConstants()
 	state.RouteExpiryTime = -1 // for testing, we want routes to expire immediately


### PR DESCRIPTION
Nylon compares a route's metric + link metric vs only the advertised metric. This is unfair, and incorrect.