### PR TITLE
fix(core): small logic bugs

### DIFF
--- a/core/ipc.go
+++ b/core/ipc.go
@@ -148,7 +148,11 @@ func HandleNylonIPCGet(n *Nylon, rw *bufio.ReadWriter) error {
 		sb.WriteString("\n\nForward Table:\n")
 		rt = make([]string, 0)
 		for prefix, route := range n.router.ForwardTable.All() {
-			rt = append(rt, fmt.Sprintf(" - %s via %s", prefix, route.Nh))
+			if route.Blackhole {
+				rt = append(rt, fmt.Sprintf(" - %s blackhole", prefix))
+			} else {
+				rt = append(rt, fmt.Sprintf(" - %s via %s", prefix, route.Nh))
+			}
 		}
 		slices.Sort(rt)
 		sb.WriteString(strings.Join(rt, "\n") + "\n")

--- a/core/nylon_tc.go
+++ b/core/nylon_tc.go
@@ -55,6 +55,9 @@ func (n *Nylon) InstallTC() {
 		n.Device.InstallFilter(func(dev *device.Device, packet *device.TCElement) (device.TCAction, error) {
 			entry, ok := n.router.ForwardTable.Lookup(packet.GetDst())
 			if ok && !packet.Incoming() {
+				if entry.Blackhole {
+					return device.TcDrop, nil
+				}
 				packet.ToPeer = entry.Peer
 				if state.DBG_trace_tc {
 					t.Submit(fmt.Sprintf("Fwd packet: %v -> %v, via %s\n", packet.GetSrc(), packet.GetDst(), entry.Nh))
@@ -68,6 +71,9 @@ func (n *Nylon) InstallTC() {
 		n.Device.InstallFilter(func(dev *device.Device, packet *device.TCElement) (device.TCAction, error) {
 			entry, ok := n.router.ForwardTable.Lookup(packet.GetDst())
 			if ok {
+				if entry.Blackhole {
+					return device.TcDrop, nil
+				}
 				packet.ToPeer = entry.Peer
 				if state.DBG_trace_tc {
 					t.Submit(fmt.Sprintf("Fwd packet: %v -> %v, via %s\n", packet.GetSrc(), packet.GetDst(), entry.Nh))

--- a/core/router.go
+++ b/core/router.go
@@ -15,8 +15,9 @@ import (
 )
 
 type RouteTableEntry struct {
-	Nh   state.NodeId
-	Peer *device.Peer
+	Nh        state.NodeId
+	Peer      *device.Peer
+	Blackhole bool
 }
 
 func (n *Nylon) GetNeighIO(neigh state.NodeId) *IOPending {
@@ -97,6 +98,14 @@ func (n *Nylon) UpdateNeighbour(neigh state.NodeId) {
 
 func (n *Nylon) TableInsertRoute(prefix netip.Prefix, route state.SelRoute) {
 	nh := route.Nh
+	if route.Metric == state.INF {
+		n.router.ForwardTable.Insert(prefix, RouteTableEntry{
+			Nh:        nh,
+			Blackhole: true,
+		})
+		n.router.ExitTable.Delete(prefix)
+		return
+	}
 	peer := n.Device.LookupPeer(device.NoisePublicKey(n.GetNode(nh).PubKey))
 	n.router.ForwardTable.Insert(prefix, RouteTableEntry{
 		Nh:   nh,

--- a/core/router.go
+++ b/core/router.go
@@ -291,6 +291,7 @@ func (n *Nylon) routerHandleRouteUpdate(node state.NodeId, update *protocol.Ny_U
 			Metric: update.Metric,
 		},
 	})
+	ComputeRoutes(n.RouterState, n)
 	return nil
 }
 

--- a/core/router_algo.go
+++ b/core/router_algo.go
@@ -217,7 +217,7 @@ func HandleSeqnoRequest(s *state.RouterState, r Router, fromNeigh state.NodeId, 
 						//   *  if the node has one or more feasible routes towards the requested
 						//      prefix with a next hop that is not the requesting node, then the
 						//      node MUST forward the request to the next hop of one such route;
-						if src.Prefix == route.Prefix && checkFeasibility(s, route.PubRoute) {
+						if src.Prefix == route.Prefix && neigh != fromNeigh && checkFeasibility(s, route.PubRoute) {
 							nh = &neigh
 							return true // found a feasible route
 						}
@@ -539,6 +539,11 @@ func ComputeRoutes(s *state.RouterState, r Router) {
 				newTable[prefix] = newRoute
 			} else {
 				// check if we should switch to this route
+				if oldRoute.Metric == newRoute.Metric {
+					if prevRoute, ok := s.Routes[prefix]; ok && sameRoute(oldRoute, prevRoute) {
+						continue
+					}
+				}
 				if ShouldSwitch(oldRoute, newRoute) {
 					newTable[prefix] = newRoute
 				}
@@ -659,4 +664,8 @@ func ShouldSwitch(curRoute state.SelRoute, newRoute state.SelRoute) bool {
 		return false
 	}
 	return true
+}
+
+func sameRoute(a state.SelRoute, b state.SelRoute) bool {
+	return a.Nh == b.Nh && a.Source == b.Source
 }

--- a/core/router_algo.go
+++ b/core/router_algo.go
@@ -82,7 +82,9 @@ func checkFeasibility(router *state.RouterState, advRoute state.PubRoute) bool {
 func FullTableUpdate(s *state.RouterState, r Router) {
 	// send a full table update to all neighbours
 	for _, route := range s.Routes {
-		updateFeasibility(s, route.PubRoute)
+		if route.Metric != state.INF {
+			updateFeasibility(s, route.PubRoute)
+		}
 		r.BroadcastSendRouteUpdate(route.PubRoute)
 	}
 }
@@ -90,7 +92,9 @@ func FullTableUpdate(s *state.RouterState, r Router) {
 func PushFullTable(s *state.RouterState, r Router, neigh state.NodeId) {
 	// send a full table update to one neighbour
 	for _, route := range s.Routes {
-		updateFeasibility(s, route.PubRoute)
+		if route.Metric != state.INF {
+			updateFeasibility(s, route.PubRoute)
+		}
 		r.SendRouteUpdate(neigh, route.PubRoute)
 	}
 }
@@ -105,18 +109,18 @@ func RunGC(s *state.RouterState, r Router) {
 
 	// scan neighbour routes for expiry
 	for _, neigh := range s.Neighbours {
-		for src, route := range neigh.Routes {
+		for prefix, route := range neigh.Routes {
 			if now.After(route.ExpireAt) {
 				if route.Metric == state.INF {
 					// route expired and is INF, delete it
-					delete(neigh.Routes, src)
-					r.RouterEvent(log.EventRouteExpired, "expired and removed", "neigh", neigh.Id, "src", src)
+					delete(neigh.Routes, prefix)
+					r.RouterEvent(log.EventRouteExpired, "expired and removed", "neigh", neigh.Id, "prefix", prefix)
 				} else {
 					// route expired, set metric to INF
 					route.Metric = state.INF
 					route.ExpireAt = time.Now().Add(state.RouteExpiryTime) // reset expiry time
-					neigh.Routes[src] = route                              // update the route
-					r.RouterEvent(log.EventRouteExpired, "expired and marked", "neigh", neigh.Id, "src", src)
+					neigh.Routes[prefix] = route                           // update the route
+					r.RouterEvent(log.EventRouteExpired, "expired and marked", "neigh", neigh.Id, "prefix", prefix)
 				}
 			}
 		}
@@ -217,6 +221,10 @@ func HandleSeqnoRequest(s *state.RouterState, r Router, fromNeigh state.NodeId, 
 						//   *  if the node has one or more feasible routes towards the requested
 						//      prefix with a next hop that is not the requesting node, then the
 						//      node MUST forward the request to the next hop of one such route;
+						n := s.GetNeighbour(neigh)
+						if n == nil || n.BestEndpoint() == nil {
+							return false
+						}
 						if src.Prefix == route.Prefix && neigh != fromNeigh && checkFeasibility(s, route.PubRoute) {
 							nh = &neigh
 							return true // found a feasible route
@@ -227,6 +235,10 @@ func HandleSeqnoRequest(s *state.RouterState, r Router, fromNeigh state.NodeId, 
 						//      the requested prefix with a next hop that is not the requesting
 						//      node, then the node SHOULD forward the request to the next hop of
 						//      one such route.
+						n := s.GetNeighbour(neigh)
+						if n == nil || n.BestEndpoint() == nil {
+							return false
+						}
 						if src.Prefix == route.Prefix && neigh != fromNeigh {
 							nh = &neigh
 							return true // found a route
@@ -315,7 +327,7 @@ func HandleNeighbourUpdate(s *state.RouterState, r Router, neighId state.NodeId,
 		//      entry, then the update MAY be ignored;
 
 		selRoute, hasSelected := s.Routes[adv.Source.Prefix]
-		isSelected := hasSelected && selRoute.Nh == neighId
+		isSelected := hasSelected && selRoute.Nh == neighId && selRoute.Source == adv.Source
 		if !checkFeasibility(s, adv) {
 			dummy := state.SelRoute{
 				PubRoute: adv,
@@ -593,6 +605,8 @@ func ComputeRoutes(s *state.RouterState, r Router) {
 				oldRoute.Metric = state.INF
 				oldRoute.RetractedBy = nil
 				newTable[prefix] = oldRoute
+				// insert blackhole
+				r.TableInsertRoute(prefix, oldRoute)
 			}
 		}
 	}

--- a/core/router_harness.go
+++ b/core/router_harness.go
@@ -62,7 +62,8 @@ func NewMockEndpoint(node state.NodeId, metric uint32) *MockEndpoint {
 }
 
 type RouterHarness struct {
-	actions []RouterEvent
+	actions      []RouterEvent
+	tableActions []RouterEvent
 }
 
 type RouterEvent struct {
@@ -76,6 +77,8 @@ const (
 	eventBroadcastRouteUpdate  = "broadcast_route_update"
 	eventSendSeqnoRequest      = "send_seqno_request"
 	eventBroadcastSeqnoRequest = "broadcast_seqno_request"
+	eventTableInsertRoute      = "table_insert_route"
+	eventTableDeleteRoute      = "table_delete_route"
 	eventRouterLog             = "router_log"
 )
 
@@ -103,6 +106,14 @@ func BroadcastRequestSeqno(src state.Source, seqno uint16, hopCnt uint8) RouterE
 	return NewRouterEvent(eventBroadcastSeqnoRequest, src, seqno, hopCnt)
 }
 
+func TableInsert(prefix netip.Prefix, route state.SelRoute) RouterEvent {
+	return NewRouterEvent(eventTableInsertRoute, prefix, route)
+}
+
+func TableDelete(prefix netip.Prefix) RouterEvent {
+	return NewRouterEvent(eventTableDeleteRoute, prefix)
+}
+
 func RouterLog(event string, desc string, args ...any) RouterEvent {
 	eventArgs := []any{event, desc}
 	eventArgs = append(eventArgs, args...)
@@ -110,11 +121,11 @@ func RouterLog(event string, desc string, args ...any) RouterEvent {
 }
 
 func (h *RouterHarness) TableInsertRoute(prefix netip.Prefix, route state.SelRoute) {
-
+	h.tableActions = append(h.tableActions, TableInsert(prefix, route))
 }
 
 func (h *RouterHarness) TableDeleteRoute(prefix netip.Prefix) {
-
+	h.tableActions = append(h.tableActions, TableDelete(prefix))
 }
 
 func (h *RouterHarness) SendAckRetract(neigh state.NodeId, prefix netip.Prefix) {
@@ -165,6 +176,12 @@ func (h *RouterHarness) GetActions() HarnessEvents {
 	}
 
 	h.actions = make([]RouterEvent, 0)
+	return x
+}
+
+func (h *RouterHarness) GetTableActions() HarnessEvents {
+	x := slices.Clone(h.tableActions)
+	h.tableActions = make([]RouterEvent, 0)
 	return x
 }
 

--- a/core/router_test.go
+++ b/core/router_test.go
@@ -840,6 +840,228 @@ func TestRouter_KeepsSelectedRouteOnEqualMetric(t *testing.T) {
 	assert.Empty(t, h.GetActions())
 }
 
+func TestRouter_HeldRouteInstallsBlackhole(t *testing.T) {
+	ConfigureConstants()
+	// A has a covering aggregate through B and a more specific route through C.
+	// When C disappears, the specific route must become an exact blackhole while
+	// it is held; deleting only the specific route would allow the aggregate to
+	// match and forward traffic that should be blackholed.
+	//
+	//       B advertises 10.0.0.0/24
+	//       |
+	//       A
+	//       |
+	//       C advertises 10.0.0.3/32
+
+	h := &RouterHarness{}
+	aggregate := netip.MustParsePrefix("10.0.0.0/24")
+	specific := nodeToPrefix("C")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+	AC := AddLink(rs, NewMockEndpoint("C", 1))
+
+	h.NeighUpdate(rs, "B", "B", aggregate, 0, 0)
+	h.NeighUpdate(rs, "C", "C", specific, 0, 0)
+	ComputeRoutes(rs, h)
+	h.GetActions()
+	h.GetTableActions()
+
+	RemoveLink(rs, AC)
+	ComputeRoutes(rs, h)
+
+	assert.Equal(t, state.INF, rs.Routes[specific].Metric)
+	tableActions := h.GetTableActions()
+	tableActions.AssertContains(t, TableDelete(specific))
+	foundBlackhole := false
+	for _, action := range tableActions {
+		if action.Type != eventTableInsertRoute || action.Args[0] != specific {
+			continue
+		}
+		route := action.Args[1].(state.SelRoute)
+		foundBlackhole = route.Metric == state.INF
+	}
+	assert.True(t, foundBlackhole, "held route should be installed as an exact-prefix blackhole")
+}
+
+func TestRouter_SelectedNeighbourUnfeasibleSourceChangeIsUnselected(t *testing.T) {
+	ConfigureConstants()
+	// A selected B's route to P with source S. B then changes the source for
+	// the same prefix to T, but that update is unfeasible. Since the source no
+	// longer matches the selected route, A must not ignore the update as if the
+	// selected route was merely becoming unfeasible.
+	//
+	//   Prefix P is originated by router-id S.
+	//
+	//          S (origin for P)
+	//          |
+	//          B
+	//        1 |
+	//          A
+	//
+	// Initially, B advertises a route to P whose origin router-id is S at
+	// metric 0, so A selects:
+	//   P via B, source S, total metric 1.
+	//
+	// Later, B advertises the same prefix P as source T at metric 5. That update
+	// is unfeasible for T, but it is not the selected source S becoming
+	// unfeasible; it is a source change and must replace B's neighbour entry.
+
+	h := &RouterHarness{}
+	prefix := nodeToPrefix("P")
+	oldSrc := state.Source{NodeId: "S", Prefix: prefix}
+	newSrc := state.Source{NodeId: "T", Prefix: prefix}
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+	h.NeighUpdate(rs, "B", oldSrc.NodeId, prefix, 0, 0)
+	ComputeRoutes(rs, h)
+	assert.Equal(t, oldSrc, rs.Routes[prefix].Source)
+	h.GetActions()
+
+	rs.Sources[newSrc] = state.FD{Seqno: 0, Metric: 1}
+	h.NeighUpdate(rs, "B", newSrc.NodeId, prefix, 0, 5)
+	ComputeRoutes(rs, h)
+
+	assert.NotEqual(t, oldSrc, rs.GetNeighbour("B").Routes[prefix].Source)
+	assert.Equal(t, state.INF, rs.Routes[prefix].Metric)
+}
+
+func TestRouter_DoesNotSelectInactiveEndpointRoute(t *testing.T) {
+	ConfigureConstants()
+	// A has learned a route to S from B, but its only endpoint to B is inactive.
+	// An inactive endpoint should be treated as no usable link, so A must not
+	// select or install the route.
+	//
+	//          S
+	//          |
+	//          B  (advertises S at metric 0)
+	//       x  |
+	//          A
+	//
+	// x = inactive A-B endpoint
+
+	h := &RouterHarness{}
+	sPrefix := nodeToPrefix("S")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	ep := NewMockEndpoint("B", 1)
+	ep.active = false
+	_ = AddLink(rs, ep)
+
+	h.NeighUpdate(rs, "B", "S", sPrefix, 0, 0)
+	ComputeRoutes(rs, h)
+
+	_, exists := rs.Routes[sPrefix]
+	assert.False(t, exists)
+}
+
+func TestRouter_SeqnoRequestSkipsInactiveForwardingNeighbour(t *testing.T) {
+	ConfigureConstants()
+	// A receives a seqno request from B for S. C and D both have neighbour-table
+	// routes for S, but C's endpoint is inactive. A must skip C and forward the
+	// request to the reachable neighbour D.
+	//
+	//          B  (requester)
+	//        1 |
+	//          A
+	//       x / \ 1
+	//        C   D
+	//
+	// C and D both advertise S. x = inactive A-C endpoint.
+
+	h := &RouterHarness{}
+	sPrefix := nodeToPrefix("S")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C", "D"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+	inactive := NewMockEndpoint("C", 1)
+	inactive.active = false
+	_ = AddLink(rs, inactive)
+	_ = AddLink(rs, NewMockEndpoint("D", 1))
+
+	h.NeighUpdate(rs, "B", "S", sPrefix, 0, 1)
+	ComputeRoutes(rs, h)
+	h.NeighUpdate(rs, "C", "S", sPrefix, 0, 1)
+	h.NeighUpdate(rs, "D", "S", sPrefix, 0, 1)
+	h.GetActions()
+
+	HandleSeqnoRequest(rs, h, "B", state.Source{NodeId: "S", Prefix: sPrefix}, 1, 64)
+	a := h.GetActions()
+	a.AssertNotContains(t, RequestSeqno("C", state.Source{NodeId: "S", Prefix: sPrefix}, 1, 63))
+	a.AssertContains(t, RequestSeqno("D", state.Source{NodeId: "S", Prefix: sPrefix}, 1, 63))
+}
+
+func TestRouter_FullTableUpdateDoesNotUpdateFeasibilityForRetraction(t *testing.T) {
+	ConfigureConstants()
+	// A is holding a retraction for S and must continue advertising that INF
+	// route. Sending the retraction should not update A's feasibility distance:
+	// FD updates are for finite updates, not retractions.
+	//
+	//          S  (held as INF)
+	//          |
+	//          B
+	//          |
+	//          A
+	//
+	// Before full-table update: FD(S) = (seqno 0, metric 1)
+	// Held retraction sent:     S seqno 1, metric INF
+	// Expected after send:      FD(S) remains (seqno 0, metric 1)
+
+	h := &RouterHarness{}
+	prefix := nodeToPrefix("S")
+	src := state.Source{NodeId: "S", Prefix: prefix}
+	rs := &state.RouterState{
+		Id:        "A",
+		SelfSeqno: make(map[netip.Prefix]uint16),
+		Routes: map[netip.Prefix]state.SelRoute{
+			prefix: {
+				PubRoute: MakePubRoute("S", prefix, 1, state.INF),
+				Nh:       "B",
+				ExpireAt: maxTime,
+			},
+		},
+		Sources: map[state.Source]state.FD{
+			src: {Seqno: 0, Metric: 1},
+		},
+		Neighbours: MakeNeighbours("B"),
+		Advertised: make(map[netip.Prefix]state.Advertisement),
+	}
+
+	FullTableUpdate(rs, h)
+
+	assert.Equal(t, state.FD{Seqno: 0, Metric: 1}, rs.Sources[src])
+	h.GetActions().AssertContains(t, BroadcastUpdateRoute(MakePubRoute("S", prefix, 1, state.INF)))
+}
+
 func TestRouter5A_GCRoutes(t *testing.T) {
 	ConfigureConstants()
 	state.RouteExpiryTime = -1 // for testing, we want routes to expire immediately

--- a/core/router_test.go
+++ b/core/router_test.go
@@ -505,6 +505,52 @@ func TestRouterNet4A_OverlappingServiceMetricIncrease(t *testing.T) {
 	a.AssertEqual(t, BroadcastUpdateRoute(MakePubRoute("A", nodeToPrefix("A"), 5, 0)))
 }
 
+func TestRouter_SeqnoRequestNotForwardedBackToRequester(t *testing.T) {
+	ConfigureConstants()
+	// This test is for the following network with our router being A:
+	// A has a stale selected route to S through requester B. In A's neighbour
+	// table, B is still the only feasible route for S, while C has an older
+	// route to S. If B loses its route and asks A for a newer seqno before A
+	// has processed B's retraction, A must not forward the request back to B.
+	//
+	//      B  (stale route to S at metric 1)
+	//      | 1
+	//      A
+	//      | 1
+	//      C  (older route to S at metric 3)
+	//
+	// A selected route: S via B, seqno 0, metric 2
+	// B asks A for:    S seqno 1
+	// Expected:        A forwards to C
+	// Forbidden:       A forwards back to B
+
+	h := &RouterHarness{}
+	sPrefix := nodeToPrefix("S")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+	_ = AddLink(rs, NewMockEndpoint("C", 1))
+
+	h.NeighUpdate(rs, "C", "S", sPrefix, 0, 3)
+	h.NeighUpdate(rs, "B", "S", sPrefix, 0, 1)
+	ComputeRoutes(rs, h)
+	assert.Equal(t, "B", string(rs.Routes[sPrefix].Nh))
+	assert.Equal(t, state.FD{Seqno: 0, Metric: 2}, rs.Sources[state.Source{NodeId: "S", Prefix: sPrefix}])
+	h.GetActions()
+
+	HandleSeqnoRequest(rs, h, "B", state.Source{NodeId: "S", Prefix: sPrefix}, 1, 64)
+	a := h.GetActions()
+	a.AssertNotContains(t, RequestSeqno("B", state.Source{NodeId: "S", Prefix: sPrefix}, 1, 63))
+	a.AssertContains(t, RequestSeqno("C", state.Source{NodeId: "S", Prefix: sPrefix}, 1, 63))
+}
+
 func TestRouterNet5A_SelectedUnfeasibleUpdate(t *testing.T) {
 	ConfigureConstants()
 	// This test is for the following network with our router being A:
@@ -752,6 +798,46 @@ func TestRouter_UnfeasibleUpdatePreferenceUsesTotalMetric(t *testing.T) {
 	h.NeighUpdate(rs, "B", "C", cPrefix, 0, 20)
 	a := h.GetActions()
 	a.AssertNotContains(t, RequestSeqno("B", state.Source{NodeId: "C", Prefix: cPrefix}, 1, 64))
+}
+
+func TestRouter_KeepsSelectedRouteOnEqualMetric(t *testing.T) {
+	ConfigureConstants()
+	// A has two equal-cost paths to S. Once A selects B, a later recompute
+	// should not switch to C only because C appears later in the neighbour list.
+	//
+	//       B
+	//     1 | 1
+	//       A
+	//     1 | 1
+	//       C
+	//
+	// B and C both advertise S at metric 1.
+
+	h := &RouterHarness{}
+	sPrefix := nodeToPrefix("S")
+	rs := &state.RouterState{
+		Id:         "A",
+		SelfSeqno:  make(map[netip.Prefix]uint16),
+		Routes:     make(map[netip.Prefix]state.SelRoute),
+		Sources:    make(map[state.Source]state.FD),
+		Neighbours: MakeNeighbours("B", "C"),
+		Advertised: map[netip.Prefix]state.Advertisement{nodeToPrefix("A"): {NodeId: state.NodeId("A"), Expiry: maxTime}},
+	}
+
+	_ = AddLink(rs, NewMockEndpoint("B", 1))
+	_ = AddLink(rs, NewMockEndpoint("C", 1))
+
+	h.NeighUpdate(rs, "B", "S", sPrefix, 0, 1)
+	ComputeRoutes(rs, h)
+	assert.Equal(t, "B", string(rs.Routes[sPrefix].Nh))
+	h.GetActions()
+
+	h.NeighUpdate(rs, "C", "S", sPrefix, 0, 1)
+	ComputeRoutes(rs, h)
+
+	assert.Equal(t, "B", string(rs.Routes[sPrefix].Nh))
+	assert.Equal(t, uint32(2), rs.Routes[sPrefix].Metric)
+	assert.Empty(t, h.GetActions())
 }
 
 func TestRouter5A_GCRoutes(t *testing.T) {

--- a/state/endpoint.go
+++ b/state/endpoint.go
@@ -188,7 +188,10 @@ func (n *Neighbour) BestEndpoint() Endpoint {
 	var best Endpoint
 
 	for _, link := range n.Eps {
-		if best == nil || link.Metric() < best.Metric() || (link.IsActive() && !best.IsActive()) {
+		if !link.IsActive() {
+			continue
+		}
+		if best == nil || link.Metric() < best.Metric() {
 			best = link
 		}
 	}


### PR DESCRIPTION
1. Seqno requests should not be forwarded to the node that sent it
2. We should recompute routes after handling a neighbour update
3. Edge case where equal-metric routes can be unstable, depending on internal ordering
4. Held routes are not properly blackholed
5. isSelected does not check source (source could have changed)
6. Inactive endpoints are not checked properly when making routing decisions
7. Retracted routes should not update feasibility distance