### PR TITLE
ci: ensure read-only permissions on test actions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,14 +12,19 @@ on:
       - "docs/**"
       - "README.md"
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.26.3"
 
 jobs:
   unit_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -28,8 +33,10 @@ jobs:
         run: go run gotest.tools/gotestsum@latest -- --race -tags=router_test ./...
   integration:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -38,8 +45,10 @@ jobs:
         run: go run gotest.tools/gotestsum@latest -- --race -tags=integration ./integration/...
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
recently, there has been a lot of repos being compromised from gh actions... just want to make sure