### PR TITLE
feat(core): multi-link routing

### DIFF
--- a/core/ipc_handler.go
+++ b/core/ipc_handler.go
@@ -223,14 +223,20 @@ func buildEndpoints(neigh *state.Neighbour) []*protocol.EndpointInfo {
 		if ap, err := nep.DynEP.Get(); err == nil {
 			resolved = new(ap.String())
 		}
+		bindSource := ""
+		if nep.Bind.Source.IsValid() {
+			bindSource = nep.Bind.Source.String()
+		}
 		eps = append(eps, &protocol.EndpointInfo{
-			Address:         nep.DynEP.Value,
-			Resolved:        resolved,
-			Active:          ep.IsActive(),
-			RemoteInit:      ep.IsRemote(),
-			Metric:          ep.Metric(),
-			FilteredRttNs:   int64(nep.FilteredPing()),
-			StabilizedRttNs: int64(nep.StabilizedPing()),
+			Address:            nep.DynEP.Value,
+			Resolved:           resolved,
+			Active:             ep.IsActive(),
+			RemoteInit:         ep.IsRemote(),
+			Metric:             ep.Metric(),
+			FilteredRttNs:      int64(nep.FilteredPing()),
+			StabilizedRttNs:    int64(nep.StabilizedPing()),
+			LocalBindInterface: nep.Bind.Interface,
+			LocalBindSource:    bindSource,
 		})
 	}
 	slices.SortFunc(eps, func(a, b *protocol.EndpointInfo) int {

--- a/core/nylon_apply.go
+++ b/core/nylon_apply.go
@@ -70,7 +70,7 @@ func (n *Nylon) reconcileRouterState(next *state.CentralCfg) error {
 			continue
 		}
 		// configure existing neighbours
-		reconcileConfiguredEndpoints(neigh, cfg.Endpoints, &n.RouterTunables)
+		reconcileConfiguredEndpoints(neigh, configuredEndpoints(n.LocalCfg.Binds, cfg.Endpoints, &n.RouterTunables))
 		neighs = append(neighs, neigh)
 		delete(desired, neigh.Id)
 	}
@@ -88,9 +88,7 @@ func (n *Nylon) reconcileRouterState(next *state.CentralCfg) error {
 			Routes: make(map[netip.Prefix]state.NeighRoute),
 			Eps:    make([]state.Endpoint, 0, len(cfg.Endpoints)),
 		}
-		for _, ep := range cfg.Endpoints {
-			stNeigh.Eps = append(stNeigh.Eps, state.NewEndpoint(ep, false, nil, &n.RouterTunables))
-		}
+		stNeigh.Eps = append(stNeigh.Eps, configuredEndpoints(n.LocalCfg.Binds, cfg.Endpoints, &n.RouterTunables)...)
 		neighs = append(neighs, stNeigh)
 	}
 	n.RouterState.Neighbours = neighs
@@ -107,14 +105,64 @@ func (n *Nylon) reconcileRouterState(next *state.CentralCfg) error {
 	return nil
 }
 
-func reconcileConfiguredEndpoints(neigh *state.Neighbour, desired []*state.DynamicEndpoint, t *state.RouterTunables) {
-	desiredByValue := make(map[string]*state.DynamicEndpoint, len(desired))
+func configuredEndpoints(binds []state.LocalBind, endpoints []*state.DynamicEndpoint, t *state.RouterTunables) []state.Endpoint {
+	if len(binds) == 0 {
+		eps := make([]state.Endpoint, 0, len(endpoints))
+		for _, ep := range endpoints {
+			eps = append(eps, state.NewEndpoint(ep, false, nil, t))
+		}
+		return eps
+	}
+
+	eps := make([]state.Endpoint, 0, len(endpoints)*len(binds))
+	for _, ep := range endpoints {
+		for _, bind := range binds {
+			if !bindMatchesEndpoint(bind, ep) {
+				continue
+			}
+			nep := state.NewEndpoint(ep, false, nil, t)
+			nep.Bind = bind
+			eps = append(eps, nep)
+		}
+	}
+	return eps
+}
+
+func bindMatchesEndpoint(bind state.LocalBind, ep *state.DynamicEndpoint) bool {
+	if !bind.Source.IsValid() {
+		return true
+	}
+	host, _, err := ep.Parse()
+	if err != nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return true
+	}
+	return state.SameIPFamily(bind.Source, addr)
+}
+
+type endpointIdentity struct {
+	value string
+	bind  state.LocalBind
+}
+
+func endpointKey(ep *state.NylonEndpoint) endpointIdentity {
+	return endpointIdentity{
+		value: ep.DynEP.Value,
+		bind:  ep.Bind,
+	}
+}
+
+func reconcileConfiguredEndpoints(neigh *state.Neighbour, desired []state.Endpoint) {
+	desiredByKey := make(map[endpointIdentity]state.Endpoint, len(desired))
 	for _, ep := range desired {
-		desiredByValue[ep.Value] = ep
+		desiredByKey[endpointKey(ep.AsNylonEndpoint())] = ep
 	}
 
 	eps := make([]state.Endpoint, 0, len(neigh.Eps)+len(desired))
-	seen := make(map[string]struct{}, len(desired))
+	seen := make(map[endpointIdentity]struct{}, len(desired))
 	for _, ep := range neigh.Eps {
 		nep := ep.AsNylonEndpoint()
 		if ep.IsRemote() {
@@ -122,16 +170,18 @@ func reconcileConfiguredEndpoints(neigh *state.Neighbour, desired []*state.Dynam
 			continue
 		}
 		// only keep if desired
-		if desiredEp, ok := desiredByValue[nep.DynEP.Value]; ok {
+		key := endpointKey(nep)
+		if _, ok := desiredByKey[key]; ok {
 			eps = append(eps, ep)
-			seen[desiredEp.Value] = struct{}{}
+			seen[key] = struct{}{}
 		}
 	}
 	for _, ep := range desired {
-		if _, ok := seen[ep.Value]; ok {
+		key := endpointKey(ep.AsNylonEndpoint())
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		eps = append(eps, state.NewEndpoint(ep, false, nil, t))
+		eps = append(eps, ep)
 	}
 	neigh.Eps = eps
 }

--- a/core/nylon_apply_test.go
+++ b/core/nylon_apply_test.go
@@ -134,3 +134,32 @@ func testCentralConfig(id state.NodeId, prefixes ...state.PrefixHealthWrapper) s
 		},
 	}
 }
+
+func TestConfiguredEndpointsExpandsBindsAcrossMatchingEndpointFamilies(t *testing.T) {
+	tunables := state.DefaultRouterTunables()
+	eps := configuredEndpoints([]state.LocalBind{
+		{Source: netip.MustParseAddr("192.0.2.10")},
+		{Source: netip.MustParseAddr("2001:db8::10")},
+	}, []*state.DynamicEndpoint{
+		state.NewDynamicEndpoint("198.51.100.10:57175"),
+		state.NewDynamicEndpoint("[2001:db8::20]:57175"),
+	}, &tunables)
+
+	assert.Len(t, eps, 2)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.10"), eps[0].AsNylonEndpoint().Bind.Source)
+	assert.Equal(t, "198.51.100.10:57175", eps[0].AsNylonEndpoint().DynEP.Value)
+	assert.Equal(t, netip.MustParseAddr("2001:db8::10"), eps[1].AsNylonEndpoint().Bind.Source)
+	assert.Equal(t, "[2001:db8::20]:57175", eps[1].AsNylonEndpoint().DynEP.Value)
+}
+
+func TestConfiguredEndpointsUsesDefaultEndpointWhenNoBindsConfigured(t *testing.T) {
+	tunables := state.DefaultRouterTunables()
+	eps := configuredEndpoints(nil, []*state.DynamicEndpoint{
+		state.NewDynamicEndpoint("198.51.100.10:57175"),
+		state.NewDynamicEndpoint("[2001:db8::20]:57175"),
+	}, &tunables)
+
+	assert.Len(t, eps, 2)
+	assert.False(t, eps[0].AsNylonEndpoint().Bind.Source.IsValid())
+	assert.False(t, eps[1].AsNylonEndpoint().Bind.Source.IsValid())
+}

--- a/core/nylon_endpoints.go
+++ b/core/nylon_endpoints.go
@@ -17,6 +17,7 @@ import (
 type EpPing struct {
 	TimeSent time.Time
 	Peer     state.NodeId
+	Endpoint *state.NylonEndpoint
 	Complete func(protocol.EndpointProbeStatus, time.Duration)
 }
 
@@ -92,6 +93,7 @@ func (n *Nylon) sendEndpointProbe(node state.NodeId, ep *state.NylonEndpoint, ti
 	n.PingBuf.Set(token, EpPing{
 		TimeSent: sentAt,
 		Peer:     node,
+		Endpoint: ep,
 		Complete: func(status protocol.EndpointProbeStatus, latency time.Duration) {
 			if timeoutTimer != nil {
 				timeoutTimer.Stop()
@@ -197,32 +199,24 @@ func handleProbePong(n *Nylon, node state.NodeId, token uint64, ep conn.Endpoint
 		n.Log.Warn("probe came back from wrong peer", "expected", health.Peer, "actual", node)
 		return
 	}
-	receivedAt := time.Now()
-	latency := receivedAt.Sub(health.TimeSent)
+	latency := time.Since(health.TimeSent)
 	health.Complete(protocol.EndpointProbeStatus_ENDPOINT_PROBE_REPLIED, latency)
 
-	// check if link exists
-	for _, neigh := range n.RouterState.Neighbours {
-		for _, dep := range neigh.Eps {
-			dpLink := dep.AsNylonEndpoint()
-			ap, err := dpLink.DynEP.Get()
-			if err == nil && ap == ep.DstIPPort() && neigh.Id == node {
-				// we have a link
-				if n.DBG_log_probe {
-					n.Log.Debug("probe back", "peer", node, "ping", latency)
-				}
-				dpLink.Renew()
-				dpLink.UpdatePing(latency)
-
-				// update wireguard endpoint
-				dpLink.WgEndpoint = ep
-
-				ComputeRoutes(n.RouterState, n)
-				return
-			}
-		}
+	dpLink := health.Endpoint
+	if dpLink == nil {
+		n.Log.Warn("probe came back without a recorded endpoint", "from", ep.DstToString(), "node", node)
+		return
 	}
-	n.Log.Warn("probe came back and couldn't find link", "from", ep.DstToString(), "node", node)
+	if n.DBG_log_probe {
+		n.Log.Debug("probe back", "peer", node, "ping", latency)
+	}
+	dpLink.Renew()
+	dpLink.UpdatePing(latency)
+
+	// Record the reply's current WireGuard endpoint on the endpoint that sent the probe.
+	dpLink.WgEndpoint = ep
+
+	ComputeRoutes(n.RouterState, n)
 }
 
 func (n *Nylon) probeLinks(active bool) error {

--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -22,6 +22,14 @@ log_path: "" # write logs to this file (empty = stderr only)
 interface_name: "" # override the interface name (default: "nylon", or utunX on macOS)
 dns_resolvers: [] # DNS servers for nylon's own lookups, e.g. ["1.1.1.1:53"]
 
+# Local endpoint selectors. Nylon probes each peer endpoint through matching
+# binds and uses the best active link for the routing edge.
+binds:
+  - interface: eth0
+    source: 192.0.2.10
+  - interface: eth0
+    source: 2001:db8::10
+
 # Bootstrap: fetch central.yaml from a remote bundle on first start
 dist:
   url: https://static.example.com/network1.nybundle

--- a/docs/reference/endpoint-local-binds.mdx
+++ b/docs/reference/endpoint-local-binds.mdx
@@ -1,0 +1,77 @@
+# Endpoint Local Binds
+
+Nylon keeps routing decisions separate from transport endpoint selection.
+Routing chooses which node to visit next. Endpoint selection chooses which
+underlay address, source address, and local interface are used for the UDP
+packet sent to that next node.
+
+## Model
+
+At the routing level, a neighbour is represented once. Multiple underlay
+endpoints for the same neighbour are link-level candidates for the same routing
+edge, and Nylon surfaces the best active endpoint metric to the router.
+
+At the link level, a Nylon endpoint may carry an optional local bind selector:
+
+- source address: the local address to use for the outgoing UDP packet
+- interface index: the local interface to constrain the outgoing UDP packet to
+
+The source address and endpoint address must be in the same IP family when a
+source address is configured. If no local bind selector is configured, endpoint
+traffic uses the kernel's normal source address and route selection.
+
+Users configure local bind selectors in `node.yaml`:
+
+```yaml
+binds:
+  - interface: eth0
+    source: 192.0.2.10
+  - interface: eth0
+    source: 2001:db8::10
+```
+
+For each peer endpoint, Nylon creates link-level candidates for the configured
+binds whose source address family matches the remote endpoint. Interface-only
+binds are applied to all endpoint families. If `binds` is empty, Nylon keeps the
+default behaviour and creates one unbound candidate per endpoint.
+
+This design does not create one socket per local bind. A Nylon device owns one
+IPv4 UDP socket and one IPv6 UDP socket when both address families are
+available. Local bind selectors are attached to endpoint sends.
+
+## Linux Transport
+
+On Linux, endpoint-local binds are encoded as per-message ancillary data:
+
+- IPv4 uses `IP_PKTINFO` with `in_pktinfo.ipi_spec_dst` and
+  `in_pktinfo.ipi_ifindex`.
+- IPv6 uses `IPV6_PKTINFO` with `in6_pktinfo.ipi6_addr` and
+  `in6_pktinfo.ipi6_ifindex`.
+
+When both a source address and interface index are provided, Nylon sends both in
+the packet info control message. The source address remains the requested source
+address; the interface index constrains output interface selection. When only an
+interface is provided, the packet info source address is left unspecified and
+the kernel may select an address for that interface.
+
+This keeps probe packets and other control traffic precise without changing the
+socket-level bind. It also allows different endpoints for the same peer to use
+different local bind selectors while still sharing the device sockets.
+
+## Non-Linux Platforms
+
+The endpoint-local bind mechanism is currently implemented only for Linux.
+Other platforms keep the default socket behaviour. A cross-platform user-facing
+configuration should only expose selectors that the current platform can honor,
+or should fail validation before the device starts.
+
+## Routing Behaviour
+
+Endpoint-local binds affect only the link-level endpoint used to send packets.
+They do not create additional routing-level neighbours or independent routed
+edges. Nylon still computes routes over nodes and uses the best active endpoint
+metric for each neighbour.
+
+Bandwidth aggregation, ECMP, and max-flow style forwarding are outside this
+model. Supporting those would require different routing semantics rather than
+additional endpoint-local bind selectors.

--- a/polyamide/conn/bind_std.go
+++ b/polyamide/conn/bind_std.go
@@ -526,6 +526,7 @@ func splitCoalescedMessages(msgs []ipv6.Message, firstMsgAt int, getGSO getGSOFu
 		if err != nil {
 			return n, err
 		}
+		control := append([]byte(nil), msg.OOB[:msg.NN]...)
 		if gsoSize > 0 {
 			numToSplit = (msg.N + gsoSize - 1) / gsoSize
 			end = gsoSize
@@ -536,6 +537,8 @@ func splitCoalescedMessages(msgs []ipv6.Message, firstMsgAt int, getGSO getGSOFu
 			}
 			copied := copy(msgs[n].Buffers[0], msg.Buffers[0][start:end])
 			msgs[n].N = copied
+			msgs[n].OOB = append(msgs[n].OOB[:0], control...)
+			msgs[n].NN = len(control)
 			msgs[n].Addr = msg.Addr
 			start = end
 			end += gsoSize

--- a/polyamide/conn/bind_std.go
+++ b/polyamide/conn/bind_std.go
@@ -374,12 +374,12 @@ func (s *StdNetBind) Send(bufs [][]byte, endpoint Endpoint) error {
 	defer s.udpAddrPool.Put(ua)
 	if is6 {
 		as16 := endpoint.DstIP().As16()
-		copy(ua.IP, as16[:])
 		ua.IP = ua.IP[:16]
+		copy(ua.IP, as16[:])
 	} else {
 		as4 := endpoint.DstIP().As4()
-		copy(ua.IP, as4[:])
 		ua.IP = ua.IP[:4]
+		copy(ua.IP, as4[:])
 	}
 	ua.Port = int(endpoint.(*StdNetEndpoint).Port())
 	var (

--- a/polyamide/conn/bind_std_test.go
+++ b/polyamide/conn/bind_std_test.go
@@ -248,3 +248,27 @@ func Test_splitCoalescedMessages(t *testing.T) {
 		})
 	}
 }
+
+func Test_splitCoalescedMessagesPreservesControl(t *testing.T) {
+	msgs := []ipv6.Message{
+		{Buffers: [][]byte{make([]byte, 1<<16-1)}, OOB: make([]byte, 0, 2)},
+		{Buffers: [][]byte{make([]byte, 1<<16-1)}, OOB: make([]byte, 0, 2)},
+		{Buffers: [][]byte{make([]byte, 1<<16-1)}, N: 2, NN: 2, OOB: []byte{1, 0}},
+		{Buffers: [][]byte{make([]byte, 1<<16-1)}, OOB: make([]byte, 0, 2)},
+	}
+	got, err := splitCoalescedMessages(msgs, 2, mockGetGSOSize)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("got to eval: %d want: %d", got, 2)
+	}
+	for i := 0; i < got; i++ {
+		if msgs[i].NN != 2 {
+			t.Fatalf("msg[%d].NN: %d want: 2", i, msgs[i].NN)
+		}
+		if gotGSO, err := mockGetGSOSize(msgs[i].OOB[:msgs[i].NN]); err != nil || gotGSO != 1 {
+			t.Fatalf("msg[%d] gso: %d err: %v", i, gotGSO, err)
+		}
+	}
+}

--- a/polyamide/conn/sticky_default.go
+++ b/polyamide/conn/sticky_default.go
@@ -21,6 +21,8 @@ func (e *StdNetEndpoint) SrcToString() string {
 	return ""
 }
 
+func (e *StdNetEndpoint) SetSrc(addr netip.Addr, ifidx int32) {}
+
 // TODO: macOS, FreeBSD and other BSDs likely do support the sticky sockets
 // {get,set}srcControl feature set, but use alternatively named flags and need
 // ports and require testing.

--- a/polyamide/conn/sticky_linux.go
+++ b/polyamide/conn/sticky_linux.go
@@ -45,6 +45,54 @@ func (e *StdNetEndpoint) SrcToString() string {
 	return e.SrcIP().String()
 }
 
+func (e *StdNetEndpoint) SetSrc(addr netip.Addr, ifidx int32) {
+	if !addr.IsValid() && ifidx == 0 {
+		e.ClearSrc()
+		return
+	}
+	if !addr.IsValid() {
+		addr = netip.AddrFrom16([16]byte{})
+		if e.DstIP().Is4() {
+			addr = netip.AddrFrom4([4]byte{})
+		}
+	}
+	if addr.Is4() {
+		if e.src == nil || cap(e.src) < unix.CmsgSpace(unix.SizeofInet4Pktinfo) {
+			e.src = make([]byte, 0, unix.CmsgSpace(unix.SizeofInet4Pktinfo))
+		}
+		e.src = e.src[:unix.CmsgSpace(unix.SizeofInet4Pktinfo)]
+		hdr := unix.Cmsghdr{
+			Level: unix.IPPROTO_IP,
+			Type:  unix.IP_PKTINFO,
+		}
+		hdr.SetLen(unix.CmsgLen(unix.SizeofInet4Pktinfo))
+		copy(e.src, unsafe.Slice((*byte)(unsafe.Pointer(&hdr)), int(unsafe.Sizeof(hdr))))
+		info := unix.Inet4Pktinfo{
+			Ifindex:  ifidx,
+			Spec_dst: addr.As4(),
+		}
+		copy(e.src[unix.CmsgLen(0):], unsafe.Slice((*byte)(unsafe.Pointer(&info)), unix.SizeofInet4Pktinfo))
+		return
+	}
+	if addr.Is6() {
+		if e.src == nil || cap(e.src) < unix.CmsgSpace(unix.SizeofInet6Pktinfo) {
+			e.src = make([]byte, 0, unix.CmsgSpace(unix.SizeofInet6Pktinfo))
+		}
+		e.src = e.src[:unix.CmsgSpace(unix.SizeofInet6Pktinfo)]
+		hdr := unix.Cmsghdr{
+			Level: unix.IPPROTO_IPV6,
+			Type:  unix.IPV6_PKTINFO,
+		}
+		hdr.SetLen(unix.CmsgLen(unix.SizeofInet6Pktinfo))
+		copy(e.src, unsafe.Slice((*byte)(unsafe.Pointer(&hdr)), int(unsafe.Sizeof(hdr))))
+		info := unix.Inet6Pktinfo{
+			Ifindex: uint32(ifidx),
+			Addr:    addr.As16(),
+		}
+		copy(e.src[unix.CmsgLen(0):], unsafe.Slice((*byte)(unsafe.Pointer(&info)), unix.SizeofInet6Pktinfo))
+	}
+}
+
 // getSrcFromControl parses the control for PKTINFO and if found updates ep with
 // the source information found.
 func getSrcFromControl(control []byte, ep *StdNetEndpoint) {

--- a/polyamide/conn/sticky_linux_test.go
+++ b/polyamide/conn/sticky_linux_test.go
@@ -54,6 +54,49 @@ func setSrc(ep *StdNetEndpoint, addr netip.Addr, ifidx int32) {
 }
 
 func Test_setSrcControl(t *testing.T) {
+	t.Run("SetSrcStoresPacketInfo", func(t *testing.T) {
+		ep := &StdNetEndpoint{
+			AddrPort: netip.MustParseAddrPort("127.0.0.1:1234"),
+		}
+		ep.SetSrc(netip.MustParseAddr("127.0.0.1"), 5)
+
+		control := make([]byte, stickyControlSize)
+		setSrcControl(&control, ep)
+
+		info := (*unix.Inet4Pktinfo)(unsafe.Pointer(&control[unix.CmsgLen(0)]))
+		if info.Spec_dst != [4]byte{127, 0, 0, 1} {
+			t.Errorf("unexpected address: %v", info.Spec_dst)
+		}
+		if info.Ifindex != 5 {
+			t.Errorf("unexpected ifindex: %d", info.Ifindex)
+		}
+	})
+
+	t.Run("SetSrcStoresInterfaceOnlyPacketInfo", func(t *testing.T) {
+		ep := &StdNetEndpoint{
+			AddrPort: netip.MustParseAddrPort("127.0.0.1:1234"),
+		}
+		ep.SetSrc(netip.Addr{}, 5)
+
+		control := make([]byte, stickyControlSize)
+		setSrcControl(&control, ep)
+
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		if hdr.Level != unix.IPPROTO_IP {
+			t.Errorf("unexpected level: %d", hdr.Level)
+		}
+		if hdr.Type != unix.IP_PKTINFO {
+			t.Errorf("unexpected type: %d", hdr.Type)
+		}
+		info := (*unix.Inet4Pktinfo)(unsafe.Pointer(&control[unix.CmsgLen(0)]))
+		if info.Spec_dst != [4]byte{} {
+			t.Errorf("unexpected address: %v", info.Spec_dst)
+		}
+		if info.Ifindex != 5 {
+			t.Errorf("unexpected ifindex: %d", info.Ifindex)
+		}
+	})
+
 	t.Run("IPv4", func(t *testing.T) {
 		ep := &StdNetEndpoint{
 			AddrPort: netip.MustParseAddrPort("127.0.0.1:1234"),

--- a/polyamide/device/peer.go
+++ b/polyamide/device/peer.go
@@ -136,11 +136,6 @@ func (peer *Peer) SendBuffers(buffers [][]byte, eps []conn.Endpoint) error {
 		for _, ep := range endpoints {
 			ep.ClearSrc()
 		}
-		for _, ep := range eps {
-			if ep != nil {
-				ep.ClearSrc()
-			}
-		}
 		peer.endpoints.clearSrcOnTx = false
 	}
 	peer.endpoints.Unlock()

--- a/protocol/nylon_ipc.pb.go
+++ b/protocol/nylon_ipc.pb.go
@@ -641,16 +641,18 @@ func (x *Advertisement) GetPassiveHold() bool {
 }
 
 type EndpointInfo struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Address         string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
-	Resolved        *string                `protobuf:"bytes,2,opt,name=resolved,proto3,oneof" json:"resolved,omitempty"`
-	Active          bool                   `protobuf:"varint,3,opt,name=active,proto3" json:"active,omitempty"`
-	RemoteInit      bool                   `protobuf:"varint,4,opt,name=remote_init,json=remoteInit,proto3" json:"remote_init,omitempty"`
-	Metric          uint32                 `protobuf:"varint,5,opt,name=metric,proto3" json:"metric,omitempty"`
-	FilteredRttNs   int64                  `protobuf:"varint,7,opt,name=filtered_rtt_ns,json=filteredRttNs,proto3" json:"filtered_rtt_ns,omitempty"`
-	StabilizedRttNs int64                  `protobuf:"varint,8,opt,name=stabilized_rtt_ns,json=stabilizedRttNs,proto3" json:"stabilized_rtt_ns,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Address            string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	Resolved           *string                `protobuf:"bytes,2,opt,name=resolved,proto3,oneof" json:"resolved,omitempty"`
+	Active             bool                   `protobuf:"varint,3,opt,name=active,proto3" json:"active,omitempty"`
+	RemoteInit         bool                   `protobuf:"varint,4,opt,name=remote_init,json=remoteInit,proto3" json:"remote_init,omitempty"`
+	Metric             uint32                 `protobuf:"varint,5,opt,name=metric,proto3" json:"metric,omitempty"`
+	FilteredRttNs      int64                  `protobuf:"varint,7,opt,name=filtered_rtt_ns,json=filteredRttNs,proto3" json:"filtered_rtt_ns,omitempty"`
+	StabilizedRttNs    int64                  `protobuf:"varint,8,opt,name=stabilized_rtt_ns,json=stabilizedRttNs,proto3" json:"stabilized_rtt_ns,omitempty"`
+	LocalBindInterface string                 `protobuf:"bytes,10,opt,name=local_bind_interface,json=localBindInterface,proto3" json:"local_bind_interface,omitempty"`
+	LocalBindSource    string                 `protobuf:"bytes,11,opt,name=local_bind_source,json=localBindSource,proto3" json:"local_bind_source,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *EndpointInfo) Reset() {
@@ -730,6 +732,20 @@ func (x *EndpointInfo) GetStabilizedRttNs() int64 {
 		return x.StabilizedRttNs
 	}
 	return 0
+}
+
+func (x *EndpointInfo) GetLocalBindInterface() string {
+	if x != nil {
+		return x.LocalBindInterface
+	}
+	return ""
+}
+
+func (x *EndpointInfo) GetLocalBindSource() string {
+	if x != nil {
+		return x.LocalBindSource
+	}
+	return ""
 }
 
 type WireGuardPeerStats struct {
@@ -1872,7 +1888,7 @@ const file_protocol_nylon_ipc_proto_rawDesc = "" +
 	"\x06metric\x18\x03 \x01(\rR\x06metric\x12\x1f\n" +
 	"\vexpiry_unix\x18\x04 \x01(\x03R\n" +
 	"expiryUnix\x12!\n" +
-	"\fpassive_hold\x18\x05 \x01(\bR\vpassiveHold\"\xfb\x01\n" +
+	"\fpassive_hold\x18\x05 \x01(\bR\vpassiveHold\"\xd9\x02\n" +
 	"\fEndpointInfo\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1f\n" +
 	"\bresolved\x18\x02 \x01(\tH\x00R\bresolved\x88\x01\x01\x12\x16\n" +
@@ -1881,7 +1897,10 @@ const file_protocol_nylon_ipc_proto_rawDesc = "" +
 	"remoteInit\x12\x16\n" +
 	"\x06metric\x18\x05 \x01(\rR\x06metric\x12&\n" +
 	"\x0ffiltered_rtt_ns\x18\a \x01(\x03R\rfilteredRttNs\x12*\n" +
-	"\x11stabilized_rtt_ns\x18\b \x01(\x03R\x0fstabilizedRttNsB\v\n" +
+	"\x11stabilized_rtt_ns\x18\b \x01(\x03R\x0fstabilizedRttNs\x120\n" +
+	"\x14local_bind_interface\x18\n" +
+	" \x01(\tR\x12localBindInterface\x12*\n" +
+	"\x11local_bind_source\x18\v \x01(\tR\x0flocalBindSourceB\v\n" +
 	"\t_resolved\"\xf0\x01\n" +
 	"\x12WireGuardPeerStats\x122\n" +
 	"\x15latest_handshake_unix\x18\x01 \x01(\x03R\x13latestHandshakeUnix\x12\x19\n" +

--- a/protocol/nylon_ipc.proto
+++ b/protocol/nylon_ipc.proto
@@ -64,6 +64,8 @@ message EndpointInfo {
   uint32 metric = 5;
   int64 filtered_rtt_ns = 7;
   int64 stabilized_rtt_ns = 8;
+  string local_bind_interface = 10;
+  string local_bind_source = 11;
 }
 
 message WireGuardPeerStats {

--- a/state/config.go
+++ b/state/config.go
@@ -64,6 +64,7 @@ type LocalCfg struct {
 	PreDown          []string              `yaml:"pre_down,omitempty"`           // a list of commands executed in order before the nylon interface is brought down
 	PostUp           []string              `yaml:"post_up,omitempty"`            // a list of commands executed in order after the nylon interface is brought up
 	PostDown         []string              `yaml:"post_down,omitempty"`          // a list of commands executed in order after the nylon interface is brought down
+	Binds            []LocalBind           `yaml:"binds,omitempty"`              // local source/interface selectors used for endpoint probing
 }
 
 func (c *CentralCfg) Clone() (error, *CentralCfg) {

--- a/state/config_test.go
+++ b/state/config_test.go
@@ -1,9 +1,12 @@
 package state
 
 import (
+	"net/netip"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,4 +151,48 @@ func TestParseGraph_InvalidGraph(t *testing.T) {
 	failGraph(t, `1,2,3,4,5,6,7,8,9,10,11,12,13,14,15`)
 	failGraph(t, `,,,,,,,,,,,,,,,,`)
 	failGraph(t, `a=a`)
+}
+
+func TestLocalBindsParse(t *testing.T) {
+	data := []byte(`
+key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+id: alice
+port: 57175
+binds:
+  - interface: eth0
+    source: 203.0.113.10
+`)
+	var local LocalCfg
+	err := yaml.Unmarshal(data, &local)
+	assert.NoError(t, err)
+	assert.Len(t, local.Binds, 1)
+	assert.Equal(t, "eth0", local.Binds[0].Interface)
+	assert.Equal(t, netip.MustParseAddr("203.0.113.10"), local.Binds[0].Source)
+}
+
+func TestNodeConfigValidatorRejectsSelectorlessBind(t *testing.T) {
+	local := LocalCfg{
+		Id:    "alice",
+		Key:   [32]byte{1},
+		Port:  57175,
+		Binds: []LocalBind{{}},
+	}
+
+	err := NodeConfigValidator(nil, &local)
+	assert.ErrorContains(t, err, "must specify source or interface")
+}
+
+func TestNodeConfigValidatorAllowsBind(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("local binds are linux-only")
+	}
+	local := LocalCfg{
+		Id:    "alice",
+		Key:   [32]byte{1},
+		Port:  57175,
+		Binds: []LocalBind{{Source: netip.MustParseAddr("203.0.113.10")}},
+	}
+
+	err := NodeConfigValidator(nil, &local)
+	assert.NoError(t, err)
 }

--- a/state/endpoint.go
+++ b/state/endpoint.go
@@ -23,6 +23,13 @@ type Endpoint interface {
 	AsNylonEndpoint() *NylonEndpoint
 }
 
+func SameIPFamily(a, b netip.Addr) bool {
+	if !a.IsValid() || !b.IsValid() {
+		return true
+	}
+	return a.BitLen() == b.BitLen()
+}
+
 /*
 		DynamicEndpoint represents either an ip:port or a dns name. This may be resolved to a different address at any time
 
@@ -164,6 +171,7 @@ type NylonEndpoint struct {
 	remoteInit    bool
 	WgEndpoint    conn.Endpoint
 	DynEP         *DynamicEndpoint
+	Bind          LocalBind
 }
 
 func (ep *NylonEndpoint) AsNylonEndpoint() *NylonEndpoint {
@@ -175,6 +183,9 @@ func (ep *NylonEndpoint) GetWgEndpoint(device *device.Device) (conn.Endpoint, er
 	if err != nil {
 		return nil, err
 	}
+	if !SameIPFamily(ep.Bind.Source, ap.Addr()) {
+		return nil, fmt.Errorf("bind source %s does not match endpoint %s", ep.Bind.Source, ap)
+	}
 
 	if ep.WgEndpoint == nil || ep.WgEndpoint.DstIPPort() != ap {
 		wgEp, err := device.Bind().ParseEndpoint(ap.String())
@@ -182,6 +193,19 @@ func (ep *NylonEndpoint) GetWgEndpoint(device *device.Device) (conn.Endpoint, er
 			return nil, fmt.Errorf("failed to parse endpoint: %s, %v", ap.String(), err)
 		}
 		ep.WgEndpoint = wgEp
+	}
+	if setter, ok := ep.WgEndpoint.(interface {
+		SetSrc(netip.Addr, int32)
+	}); ok && (ep.Bind.Source.IsValid() || ep.Bind.Interface != "") {
+		ifidx := int32(0)
+		if ep.Bind.Interface != "" {
+			iface, err := net.InterfaceByName(ep.Bind.Interface)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve bind interface %s: %w", ep.Bind.Interface, err)
+			}
+			ifidx = int32(iface.Index)
+		}
+		setter.SetSrc(ep.Bind.Source, ifidx)
 	}
 	return ep.WgEndpoint, nil
 }

--- a/state/endpoint_test.go
+++ b/state/endpoint_test.go
@@ -3,11 +3,19 @@ package state
 import (
 	"math"
 	"math/rand/v2"
+	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSameIPFamily(t *testing.T) {
+	assert.True(t, SameIPFamily(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("198.51.100.1")))
+	assert.True(t, SameIPFamily(netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr("2001:db8::2")))
+	assert.False(t, SameIPFamily(netip.MustParseAddr("192.0.2.1"), netip.MustParseAddr("2001:db8::1")))
+	assert.True(t, SameIPFamily(netip.Addr{}, netip.MustParseAddr("2001:db8::1")))
+}
 
 type DataSource struct {
 	Name string

--- a/state/routing.go
+++ b/state/routing.go
@@ -11,6 +11,11 @@ import (
 
 type NodeId string
 
+type LocalBind struct {
+	Interface string     `yaml:"interface,omitempty"`
+	Source    netip.Addr `yaml:"source,omitempty"`
+}
+
 // Source is a pair of a router-id and a prefix (Babel Section 2.7).
 type Source struct {
 	NodeId

--- a/state/validation.go
+++ b/state/validation.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"net/url"
 	"regexp"
+	"runtime"
 	"slices"
 )
 
@@ -41,6 +42,19 @@ func NodeConfigValidator(central *CentralCfg, node *LocalCfg) error {
 		_, err := url.Parse(node.Dist.Url)
 		if err != nil {
 			return err
+		}
+	}
+	seenBinds := make(map[LocalBind]struct{})
+	for _, bind := range node.Binds {
+		if bind.Interface == "" && !bind.Source.IsValid() {
+			return fmt.Errorf("bind must specify source or interface")
+		}
+		if _, ok := seenBinds[bind]; ok {
+			return fmt.Errorf("duplicate bind %s %s", bind.Interface, bind.Source)
+		}
+		seenBinds[bind] = struct{}{}
+		if runtime.GOOS != "linux" {
+			return fmt.Errorf("local binds are only supported on linux")
 		}
 	}
 	if len(node.DnsResolvers) != 0 {


### PR DESCRIPTION
## Background 
Currently, nylon employs a "one neighbor, many candidate endpoints, one best endpoint" model. In this implementation, a neighbor is keyed strictly by its NodeId. While multiple remote endpoints can be configured for a single peer, only the single best-performing endpoint is active for routing at any given time.
This approach has several limitations:
- Lack of Interface Awareness: It cannot distinguish between different physical paths, such as reaching a peer via a local WAN interface versus a local LAN interface. 
- Restricted Control Plane: Control messages and probes are tied to the peer's primary endpoint, preventing independent liveness and metric tracking for alternative paths.
- Limited Path Redundancy: It treats all connections to a peer as a single next-hop, rather than treating independent physical or logical links as distinct routing adjacencies.

To address these constraints, this PR implements a Multi-Link Routing design. The core change shifts the routing adjacency from a "node-level" view to a "link-level" view. By introducing LocalBind (local interface/source selection), each unique (Peer, LocalBind, RemoteEndpoint) tuple is now treated as an independent routing link. This allows the router to independently track metrics for multiple paths between the same two nodes and select the optimal link for traffic based on real-time performance and local policy.

Full design: `docs/reference/multi-link-routing.mdx`.

## What changed
- **state**: add `LocalBindID`, `RemoteEndpointID`, `LinkID`, and `Link`; store links in `RouterState`; key selected routes by next-hop link (`SelRoute.NhLink`).
- **config**: parse local binds and structured endpoint IDs while keeping plain string-endpoint compatibility; reject explicit binds off Linux.
- **conn**: pair a remote endpoint with a local bind selector (sticky source / `IP_PKTINFO`) so the same remote address on different binds is a distinct link.
- **discovery**: probe the `local bind × remote endpoint` product, track probes by link, dedupe duplicate transport tuples, and skip bind/endpoint address-family mismatches.
- **router**: resolve every incoming control packet to a link before it reaches router logic; select the lowest-metric active link per peer with stable tie-breaking; carry a per-retraction acknowledgment token; keep seqno-request suppression router-wide.
- **forwarding**: set `TCElement.ToEp` from the selected link endpoint so data follows the selected link rather than the peer default endpoint.
- **status / IPC**: expose per-link bind, endpoint, and neighbour-route info.

## Supporting commits
- `fix(conn)`: `StdNetBind.Send` reused a pooled `net.UDPAddr` whose IP slice could have been shrunk to 4 bytes by a prior IPv4 send, truncating the next IPv6 destination (e.g. `2001:db8::1` → `2001:db8::`). The link then never collected RTT samples and its metric stayed at `INF`. Resize the slice before copying.
- `perf(core)`: batch a received bundle's control packets into a single dispatch that recomputes routes at most once, and coalesce pong-driven recomputation behind a pending flag, to avoid saturating the dispatch queue on multi-link meshes.

## Testing

The feature has currently been tested across a total of 12 nodes deployed in different geographic regions over the public Internet, with continuous operation exceeding 24 hours. The test coverage includes:

1. Dual-stack nodes with both IPv4 and IPv6 connectivity.
2. IPv4-only nodes.
3. Multi-homed nodes with multiple network interfaces, each assigned its own independent IP address.
4. Nodes without any publicly reachable endpoint configuration.
