### PR TITLE
Fix Windows IPv6 alias configuration

### DIFF
--- a/core/sys_windows.go
+++ b/core/sys_windows.go
@@ -29,10 +29,16 @@ func InitInterface(logger *slog.Logger, ifName string) error {
 }
 
 func ConfigureAlias(logger *slog.Logger, ifName string, addr netip.Addr) error {
+	if addr.Is6() {
+		return Exec(logger, "netsh", "interface", "ipv6", "add", "address", ifName, addr.String())
+	}
 	return Exec(logger, "netsh", "interface", "ip", "add", "address", ifName, addr.String())
 }
 
 func RemoveAlias(logger *slog.Logger, ifName string, addr netip.Addr) error {
+	if addr.Is6() {
+		return Exec(logger, "netsh", "interface", "ipv6", "delete", "address", ifName, addr.String())
+	}
 	return Exec(logger, "netsh", "interface", "ip", "delete", "address", ifName, addr.String())
 }
 


### PR DESCRIPTION
Use the netsh ipv6 context for IPv6 address aliases instead of the IPv4 interface ip context so Windows nodes can assign their Nylon ULA address.