### PR TITLE
perf(windows): batch Wintun reads and RIO sends

### DIFF
--- a/polyamide/conn/bind_windows.go
+++ b/polyamide/conn/bind_windows.go
@@ -76,6 +76,13 @@ func (rb *ringBuffer) cancelPush() {
 	rb.isFull = false
 }
 
+func rioSendFlags(batchSize int) uint32 {
+	if batchSize > 1 {
+		return winrio.MsgDefer
+	}
+	return 0
+}
+
 type afWinRingBind struct {
 	sock      windows.Handle
 	rx, tx    ringBuffer
@@ -529,6 +536,7 @@ func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *at
 
 	bind.mu.Lock()
 	defer bind.mu.Unlock()
+	sendFlags := rioSendFlags(len(bufs))
 	deferred := false
 	for _, buf := range bufs {
 		packet := bind.tx.Push()
@@ -544,7 +552,7 @@ func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *at
 			Offset: uint32(uintptr(unsafe.Pointer(&packet.addr)) - bind.tx.packets),
 			Length: uint32(unsafe.Sizeof(packet.addr)),
 		}
-		err := winrio.SendEx(bind.rq, dataBuffer, 1, nil, addressBuffer, nil, nil, winrio.MsgDefer, 0)
+		err := winrio.SendEx(bind.rq, dataBuffer, 1, nil, addressBuffer, nil, nil, sendFlags, 0)
 		if err != nil {
 			bind.tx.cancelPush()
 			if deferred {
@@ -554,7 +562,10 @@ func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *at
 			}
 			return err
 		}
-		deferred = true
+		deferred = sendFlags == winrio.MsgDefer
+	}
+	if !deferred {
+		return nil
 	}
 	return winrio.SendEx(bind.rq, nil, 0, nil, nil, nil, nil, winrio.MsgCommitOnly, 0)
 }

--- a/polyamide/conn/bind_windows.go
+++ b/polyamide/conn/bind_windows.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	packetsPerRing = 1024
-	bytesPerPacket = 2048 - 32
-	receiveSpins   = 15
+	packetsPerRing   = 1024
+	bytesPerPacket   = 2048 - 32
+	receiveSpins     = 15
+	winRingBatchSize = 16
 )
 
 type ringPacket struct {
@@ -348,8 +349,7 @@ func (bind *WinRingBind) Close() error {
 // TODO: When all Binds handle IdealBatchSize, remove this dynamic function and
 // rename the IdealBatchSize constant to BatchSize.
 func (bind *WinRingBind) BatchSize() int {
-	// TODO: implement batching in and out of the ring
-	return 1
+	return winRingBatchSize
 }
 
 func (bind *WinRingBind) SetMark(mark uint32) error {
@@ -461,18 +461,10 @@ func (bind *WinRingBind) receiveIPv6(bufs [][]byte, sizes []int, eps []Endpoint)
 	return 1, err
 }
 
-func (bind *afWinRingBind) Send(buf []byte, nend *WinRingEndpoint, isOpen *atomic.Uint32) error {
-	if isOpen.Load() != 1 {
-		return net.ErrClosed
-	}
-	if len(buf) > bytesPerPacket {
-		return io.ErrShortBuffer
-	}
-	bind.tx.mu.Lock()
-	defer bind.tx.mu.Unlock()
+func (bind *afWinRingBind) reapTransmitCompletions(isOpen *atomic.Uint32, wait bool) error {
 	var results [packetsPerRing]winrio.Result
 	count := winrio.DequeueCompletion(bind.tx.cq, results[:])
-	if count == 0 && bind.tx.isFull {
+	if count == 0 && wait {
 		err := winrio.Notify(bind.tx.cq)
 		if err != nil {
 			return err
@@ -495,22 +487,51 @@ func (bind *afWinRingBind) Send(buf []byte, nend *WinRingEndpoint, isOpen *atomi
 	if count > 0 {
 		bind.tx.Return(count)
 	}
-	packet := bind.tx.Push()
-	packet.addr = *nend
-	copy(packet.data[:], buf)
-	dataBuffer := &winrio.Buffer{
-		Id:     bind.tx.id,
-		Offset: uint32(uintptr(unsafe.Pointer(&packet.data[0])) - bind.tx.packets),
-		Length: uint32(len(buf)),
+	return nil
+}
+
+func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *atomic.Uint32) error {
+	if isOpen.Load() != 1 {
+		return net.ErrClosed
 	}
-	addressBuffer := &winrio.Buffer{
-		Id:     bind.tx.id,
-		Offset: uint32(uintptr(unsafe.Pointer(&packet.addr)) - bind.tx.packets),
-		Length: uint32(unsafe.Sizeof(packet.addr)),
+	bind.tx.mu.Lock()
+	defer bind.tx.mu.Unlock()
+
+	if err := bind.reapTransmitCompletions(isOpen, false); err != nil {
+		return err
 	}
-	bind.mu.Lock()
-	defer bind.mu.Unlock()
-	return winrio.SendEx(bind.rq, dataBuffer, 1, nil, addressBuffer, nil, nil, 0, 0)
+
+	for _, buf := range bufs {
+		if len(buf) > bytesPerPacket {
+			return io.ErrShortBuffer
+		}
+		if bind.tx.isFull {
+			if err := bind.reapTransmitCompletions(isOpen, true); err != nil {
+				return err
+			}
+		}
+
+		packet := bind.tx.Push()
+		packet.addr = *nend
+		copy(packet.data[:], buf)
+		dataBuffer := &winrio.Buffer{
+			Id:     bind.tx.id,
+			Offset: uint32(uintptr(unsafe.Pointer(&packet.data[0])) - bind.tx.packets),
+			Length: uint32(len(buf)),
+		}
+		addressBuffer := &winrio.Buffer{
+			Id:     bind.tx.id,
+			Offset: uint32(uintptr(unsafe.Pointer(&packet.addr)) - bind.tx.packets),
+			Length: uint32(unsafe.Sizeof(packet.addr)),
+		}
+		bind.mu.Lock()
+		err := winrio.SendEx(bind.rq, dataBuffer, 1, nil, addressBuffer, nil, nil, 0, 0)
+		bind.mu.Unlock()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (bind *WinRingBind) Send(bufs [][]byte, endpoint Endpoint) error {
@@ -520,22 +541,20 @@ func (bind *WinRingBind) Send(bufs [][]byte, endpoint Endpoint) error {
 	}
 	bind.mu.RLock()
 	defer bind.mu.RUnlock()
-	for _, buf := range bufs {
-		switch nend.family {
-		case windows.AF_INET:
-			if bind.v4.blackhole {
-				continue
-			}
-			if err := bind.v4.Send(buf, nend, &bind.isOpen); err != nil {
-				return err
-			}
-		case windows.AF_INET6:
-			if bind.v6.blackhole {
-				continue
-			}
-			if err := bind.v6.Send(buf, nend, &bind.isOpen); err != nil {
-				return err
-			}
+	switch nend.family {
+	case windows.AF_INET:
+		if bind.v4.blackhole {
+			return nil
+		}
+		if err := bind.v4.Send(bufs, nend, &bind.isOpen); err != nil {
+			return err
+		}
+	case windows.AF_INET6:
+		if bind.v6.blackhole {
+			return nil
+		}
+		if err := bind.v6.Send(bufs, nend, &bind.isOpen); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/polyamide/conn/bind_windows.go
+++ b/polyamide/conn/bind_windows.go
@@ -7,6 +7,7 @@ package conn
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"net/netip"
@@ -60,6 +61,18 @@ func (rb *ringBuffer) Return(count uint32) {
 		return
 	}
 	rb.head += count
+	rb.isFull = false
+}
+
+func (rb *ringBuffer) available() uint32 {
+	if rb.isFull {
+		return 0
+	}
+	return packetsPerRing - (rb.tail - rb.head)
+}
+
+func (rb *ringBuffer) cancelPush() {
+	rb.tail--
 	rb.isFull = false
 }
 
@@ -494,23 +507,30 @@ func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *at
 	if isOpen.Load() != 1 {
 		return net.ErrClosed
 	}
+	if len(bufs) == 0 {
+		return nil
+	}
+	for _, buf := range bufs {
+		if len(buf) > bytesPerPacket {
+			return io.ErrShortBuffer
+		}
+	}
 	bind.tx.mu.Lock()
 	defer bind.tx.mu.Unlock()
 
 	if err := bind.reapTransmitCompletions(isOpen, false); err != nil {
 		return err
 	}
+	for bind.tx.available() < uint32(len(bufs)) {
+		if err := bind.reapTransmitCompletions(isOpen, true); err != nil {
+			return err
+		}
+	}
 
+	bind.mu.Lock()
+	defer bind.mu.Unlock()
+	deferred := false
 	for _, buf := range bufs {
-		if len(buf) > bytesPerPacket {
-			return io.ErrShortBuffer
-		}
-		if bind.tx.isFull {
-			if err := bind.reapTransmitCompletions(isOpen, true); err != nil {
-				return err
-			}
-		}
-
 		packet := bind.tx.Push()
 		packet.addr = *nend
 		copy(packet.data[:], buf)
@@ -524,14 +544,19 @@ func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *at
 			Offset: uint32(uintptr(unsafe.Pointer(&packet.addr)) - bind.tx.packets),
 			Length: uint32(unsafe.Sizeof(packet.addr)),
 		}
-		bind.mu.Lock()
-		err := winrio.SendEx(bind.rq, dataBuffer, 1, nil, addressBuffer, nil, nil, 0, 0)
-		bind.mu.Unlock()
+		err := winrio.SendEx(bind.rq, dataBuffer, 1, nil, addressBuffer, nil, nil, winrio.MsgDefer, 0)
 		if err != nil {
+			bind.tx.cancelPush()
+			if deferred {
+				if commitErr := winrio.SendEx(bind.rq, nil, 0, nil, nil, nil, nil, winrio.MsgCommitOnly, 0); commitErr != nil {
+					return errors.Join(err, commitErr)
+				}
+			}
 			return err
 		}
+		deferred = true
 	}
-	return nil
+	return winrio.SendEx(bind.rq, nil, 0, nil, nil, nil, nil, winrio.MsgCommitOnly, 0)
 }
 
 func (bind *WinRingBind) Send(bufs [][]byte, endpoint Endpoint) error {

--- a/polyamide/conn/bind_windows.go
+++ b/polyamide/conn/bind_windows.go
@@ -25,7 +25,7 @@ const (
 	packetsPerRing   = 1024
 	bytesPerPacket   = 2048 - 32
 	receiveSpins     = 15
-	winRingBatchSize = 16
+	winRingBatchSize = 32
 )
 
 type ringPacket struct {

--- a/polyamide/conn/bind_windows.go
+++ b/polyamide/conn/bind_windows.go
@@ -28,6 +28,8 @@ const (
 	winRingBatchSize = 32
 )
 
+var errTooManyPackets = errors.New("send batch exceeds maximum batch size")
+
 type ringPacket struct {
 	addr WinRingEndpoint
 	data [bytesPerPacket]byte
@@ -516,6 +518,9 @@ func (bind *afWinRingBind) Send(bufs [][]byte, nend *WinRingEndpoint, isOpen *at
 	}
 	if len(bufs) == 0 {
 		return nil
+	}
+	if len(bufs) > winRingBatchSize {
+		return errTooManyPackets
 	}
 	for _, buf := range bufs {
 		if len(buf) > bytesPerPacket {

--- a/polyamide/conn/bind_windows_test.go
+++ b/polyamide/conn/bind_windows_test.go
@@ -3,7 +3,27 @@ package conn
 import (
 	"math"
 	"testing"
+
+	"github.com/encodeous/nylon/polyamide/conn/winrio"
 )
+
+func TestRIOSendFlags(t *testing.T) {
+	tests := []struct {
+		batchSize int
+		want      uint32
+	}{
+		{batchSize: 0, want: 0},
+		{batchSize: 1, want: 0},
+		{batchSize: 2, want: winrio.MsgDefer},
+		{batchSize: winRingBatchSize, want: winrio.MsgDefer},
+	}
+
+	for _, test := range tests {
+		if got := rioSendFlags(test.batchSize); got != test.want {
+			t.Errorf("rioSendFlags(%d) = %d, want %d", test.batchSize, got, test.want)
+		}
+	}
+}
 
 func TestRingBufferAvailable(t *testing.T) {
 	tests := []struct {

--- a/polyamide/conn/bind_windows_test.go
+++ b/polyamide/conn/bind_windows_test.go
@@ -1,0 +1,62 @@
+package conn
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRingBufferAvailable(t *testing.T) {
+	tests := []struct {
+		name string
+		ring ringBuffer
+		want uint32
+	}{
+		{
+			name: "empty",
+			want: packetsPerRing,
+		},
+		{
+			name: "partially occupied",
+			ring: ringBuffer{head: 3, tail: 13},
+			want: packetsPerRing - 10,
+		},
+		{
+			name: "wrapped counters",
+			ring: ringBuffer{head: math.MaxUint32 - 4, tail: 5},
+			want: packetsPerRing - 10,
+		},
+		{
+			name: "full",
+			ring: ringBuffer{isFull: true},
+			want: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.ring.available(); got != test.want {
+				t.Fatalf("available() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRingBufferCancelPush(t *testing.T) {
+	ring := ringBuffer{
+		head:   10,
+		tail:   11,
+		isFull: true,
+	}
+
+	ring.cancelPush()
+
+	if ring.tail != 10 {
+		t.Fatalf("tail = %d, want 10", ring.tail)
+	}
+	if ring.isFull {
+		t.Fatal("ring remains full after cancelling a push")
+	}
+	if got := ring.available(); got != packetsPerRing {
+		t.Fatalf("available() = %d, want %d", got, packetsPerRing)
+	}
+}

--- a/polyamide/conn/bind_windows_test.go
+++ b/polyamide/conn/bind_windows_test.go
@@ -1,7 +1,9 @@
 package conn
 
 import (
+	"errors"
 	"math"
+	"sync/atomic"
 	"testing"
 
 	"github.com/encodeous/nylon/polyamide/conn/winrio"
@@ -22,6 +24,17 @@ func TestRIOSendFlags(t *testing.T) {
 		if got := rioSendFlags(test.batchSize); got != test.want {
 			t.Errorf("rioSendFlags(%d) = %d, want %d", test.batchSize, got, test.want)
 		}
+	}
+}
+
+func TestRIOSendRejectsOversizedBatch(t *testing.T) {
+	var isOpen atomic.Uint32
+	isOpen.Store(1)
+
+	bind := &afWinRingBind{}
+	bufs := make([][]byte, winRingBatchSize+1)
+	if err := bind.Send(bufs, nil, &isOpen); !errors.Is(err, errTooManyPackets) {
+		t.Fatalf("Send() error = %v, want %v", err, errTooManyPackets)
 	}
 }
 

--- a/polyamide/tun/tun_windows.go
+++ b/polyamide/tun/tun_windows.go
@@ -22,6 +22,7 @@ const (
 	rateMeasurementGranularity = uint64((time.Second / 2) / time.Nanosecond)
 	spinloopRateThreshold      = 800000000 / 8                                   // 800mbps
 	spinloopDuration           = uint64(time.Millisecond / 80 / time.Nanosecond) // ~1gbit/s
+	wintunBatchSize            = 16
 )
 
 type rateJuggler struct {
@@ -146,8 +147,7 @@ func (tun *NativeTun) ForceMTU(mtu int) {
 }
 
 func (tun *NativeTun) BatchSize() int {
-	// TODO: implement batching with wintun
-	return 1
+	return wintunBatchSize
 }
 
 // Note: Read() and Write() assume the caller comes only from a single thread; there's no locking.
@@ -161,19 +161,24 @@ retry:
 	}
 	start := nanotime()
 	shouldSpin := tun.rate.current.Load() >= spinloopRateThreshold && uint64(start-tun.rate.nextStartTime.Load()) <= rateMeasurementGranularity*2
-	for {
+	count := 0
+	for count < min(len(bufs), len(sizes)) {
 		if tun.close.Load() {
-			return 0, os.ErrClosed
+			return count, os.ErrClosed
 		}
 		packet, err := tun.session.ReceivePacket()
 		switch err {
 		case nil:
-			n := copy(bufs[0][offset:], packet)
-			sizes[0] = n
+			n := copy(bufs[count][offset:], packet)
+			sizes[count] = n
 			tun.session.ReleaseReceivePacket(packet)
 			tun.rate.update(uint64(n))
-			return 1, nil
+			count++
+			continue
 		case windows.ERROR_NO_MORE_ITEMS:
+			if count > 0 {
+				return count, nil
+			}
 			if !shouldSpin || uint64(nanotime()-start) >= spinloopDuration {
 				windows.WaitForSingleObject(tun.readWait, windows.INFINITE)
 				goto retry
@@ -181,12 +186,13 @@ retry:
 			procyield(1)
 			continue
 		case windows.ERROR_HANDLE_EOF:
-			return 0, os.ErrClosed
+			return count, os.ErrClosed
 		case windows.ERROR_INVALID_DATA:
-			return 0, errors.New("Send ring corrupt")
+			return count, errors.New("Send ring corrupt")
 		}
-		return 0, fmt.Errorf("Read failed: %w", err)
+		return count, fmt.Errorf("Read failed: %w", err)
 	}
+	return count, nil
 }
 
 func (tun *NativeTun) Write(bufs [][]byte, offset int) (int, error) {

--- a/polyamide/tun/tun_windows.go
+++ b/polyamide/tun/tun_windows.go
@@ -188,7 +188,7 @@ retry:
 		case windows.ERROR_HANDLE_EOF:
 			return count, os.ErrClosed
 		case windows.ERROR_INVALID_DATA:
-			return count, errors.New("Send ring corrupt")
+			return count, errors.New("Receive ring corrupt")
 		}
 		return count, fmt.Errorf("Read failed: %w", err)
 	}

--- a/polyamide/tun/tun_windows.go
+++ b/polyamide/tun/tun_windows.go
@@ -22,7 +22,7 @@ const (
 	rateMeasurementGranularity = uint64((time.Second / 2) / time.Nanosecond)
 	spinloopRateThreshold      = 800000000 / 8                                   // 800mbps
 	spinloopDuration           = uint64(time.Millisecond / 80 / time.Nanosecond) // ~1gbit/s
-	wintunBatchSize            = 16
+	wintunBatchSize            = 32
 )
 
 type rateJuggler struct {


### PR DESCRIPTION
## Summary

Improve Windows data-plane performance by batching Wintun receives and RIO transmits.

The RIO path now reserves and submits an entire packet batch under one lock,
uses deferred sends followed by a single commit, and retains an immediate-send
fast path for single-packet traffic. The maximum Windows packet batch size is
increased from 16 to 32 based on throughput and latency testing.

## Changes

- Advertise and process bounded Wintun receive batches.
- Drain immediately available Wintun packets into the caller-provided batch.
- Drain RIO transmit completions once per batch.
- Reserve transmit-ring capacity for the complete batch under one lock.
- Submit multi-packet batches with `RIO_MSG_DEFER` and one
  `RIO_MSG_COMMIT_ONLY` request.
- Send single-packet requests immediately to avoid an unnecessary commit call
  on latency-sensitive traffic.
- Increase the Wintun and RIO batch limits from 16 to 32 packets.
- Add tests covering:
  - transmit-ring capacity and full-state handling;
  - counter wraparound;
  - failed-send rollback;
  - immediate versus deferred send flags.

Capacity is reserved before submitting deferred requests. This avoids waiting
for completions from requests that Windows has not yet committed.

## Performance

Tests ran from a Windows 11 Pro system with an Intel i7-6700K to a Linux Nylon
endpoint over a gigabit Ethernet switch and a direct Nylon link.

A bounded A/B/A comparison of the final batch-size adjustment produced:

| Forward workload | Batch 16 A1 | Batch 32 | Batch 16 A2 |
| --- | ---: | ---: | ---: |
| TCP, 1 stream | 859.24 Mbit/s | 853.90 Mbit/s | 817.72 Mbit/s |
| TCP, 4 streams | 769.53 Mbit/s | 884.53 Mbit/s | 850.59 Mbit/s |
| UDP, 1372-byte payload | 729.23 Mbit/s | 803.35 Mbit/s | 898.18 Mbit/s |
| UDP, 64-byte payload | 33.84 Mbit/s | 58.29 Mbit/s | 34.68 Mbit/s |
| UDP, 64-byte loss | 65.90% | 41.68% | 65.18% |

For the 64-byte workload, batch 32 delivered approximately 70% more traffic
than the mean of the controls, reduced loss by 23.9 percentage points, and used
approximately 27% less Nylon CPU time per delivered bit.

TCP and normal-packet UDP remained within the variability of the bracketing
controls. Batch sizes of 8 and 64 were also tested: 8 was slower, while 64
materially regressed normal-packet UDP throughput.

## Latency

An A/B/A test using a temporary UDP echo endpoint found no measurable latency
regression from increasing the batch size:

| Scenario | Metric | Batch 16 A1 | Batch 32 | Batch 16 A2 |
| --- | --- | ---: | ---: | ---: |
| Idle | p50 RTT | 1.0150 ms | 0.6506 ms | 0.8555 ms |
| Idle | p95 RTT | 1.6306 ms | 1.1083 ms | 1.3170 ms |
| Idle | p99 RTT | 2.2454 ms | 2.6347 ms | 2.8297 ms |
| TCP load | p95 RTT | 47.4889 ms | 48.0725 ms | 49.1433 ms |
| TCP load | p99 RTT | 53.6151 ms | 54.1835 ms | 55.4501 ms |

The single-packet RIO fast path also preserved batching throughput while
removing the extra defer/commit operation from interactive traffic.

## Profiling

A symbolized 20-second CPU profile during bounded 64-byte UDP traffic showed:

- `runtime.cgocall`: 85.86% of sampled CPU time;
- `RIOSendEx`: approximately 40% of cumulative samples;
- traffic-control batching: 2.30%;
- ChaCha sealing: less than 1%.

This indicates that the remaining Windows cost is predominantly at the Windows
API boundary rather than in Nylon traffic control or encryption.

## Validation

- Full `go test ./...` suite passes.
- Complete Windows executables cross-compile for amd64 and arm64.
- The Windows connection tests pass natively on Windows.
- The native tests cover ring capacity, counter wraparound, full-state
  handling, failed-send rollback, and immediate/deferred send selection.