### PR TITLE
perf(linux): batch TUN reads and trim message cleanup

### DIFF
--- a/polyamide/conn/bind_std.go
+++ b/polyamide/conn/bind_std.go
@@ -203,8 +203,8 @@ again:
 	return fns, uint16(port), nil
 }
 
-func (s *StdNetBind) putMessages(msgs *[]ipv6.Message) {
-	for i := range *msgs {
+func (s *StdNetBind) putMessages(msgs *[]ipv6.Message, count int) {
+	for i := range (*msgs)[:count] {
 		(*msgs)[i].OOB = (*msgs)[i].OOB[:0]
 		(*msgs)[i] = ipv6.Message{Buffers: (*msgs)[i].Buffers, OOB: (*msgs)[i].OOB}
 	}
@@ -241,7 +241,7 @@ func (s *StdNetBind) receiveIP(
 		(*msgs)[i].Buffers[0] = bufs[i]
 		(*msgs)[i].OOB = (*msgs)[i].OOB[:cap((*msgs)[i].OOB)]
 	}
-	defer s.putMessages(msgs)
+	defer s.putMessages(msgs, len(bufs))
 	var numMsgs int
 	if runtime.GOOS == "linux" || runtime.GOOS == "android" {
 		if rxOffload {
@@ -369,7 +369,10 @@ func (s *StdNetBind) Send(bufs [][]byte, endpoint Endpoint) error {
 	}
 
 	msgs := s.getMessages()
-	defer s.putMessages(msgs)
+	usedMessages := 0
+	defer func() {
+		s.putMessages(msgs, usedMessages)
+	}()
 	ua := s.udpAddrPool.Get().(*net.UDPAddr)
 	defer s.udpAddrPool.Put(ua)
 	if is6 {
@@ -389,6 +392,7 @@ func (s *StdNetBind) Send(bufs [][]byte, endpoint Endpoint) error {
 retry:
 	if offload {
 		n := coalesceMessages(ua, endpoint.(*StdNetEndpoint), bufs, *msgs, setGSOSize)
+		usedMessages = max(usedMessages, n)
 		err = s.send(conn, br, (*msgs)[:n])
 		if err != nil && offload && errShouldDisableUDPGSO(err) {
 			offload = false
@@ -403,6 +407,7 @@ retry:
 			goto retry
 		}
 	} else {
+		usedMessages = max(usedMessages, len(bufs))
 		for i := range bufs {
 			(*msgs)[i].Addr = ua
 			(*msgs)[i].Buffers[0] = bufs[i]

--- a/polyamide/conn/bind_std.go
+++ b/polyamide/conn/bind_std.go
@@ -241,7 +241,13 @@ func (s *StdNetBind) receiveIP(
 		(*msgs)[i].Buffers[0] = bufs[i]
 		(*msgs)[i].OOB = (*msgs)[i].OOB[:cap((*msgs)[i].OOB)]
 	}
-	defer s.putMessages(msgs, len(bufs))
+	cleanupCount := len(bufs)
+	if runtime.GOOS == "linux" || runtime.GOOS == "android" {
+		// ReadBatch receives the full message slice, or its tail when GRO is
+		// enabled, and splitCoalescedMessages can populate the full front range.
+		cleanupCount = len(*msgs)
+	}
+	defer s.putMessages(msgs, cleanupCount)
 	var numMsgs int
 	if runtime.GOOS == "linux" || runtime.GOOS == "android" {
 		if rxOffload {

--- a/polyamide/conn/bind_std_linux_test.go
+++ b/polyamide/conn/bind_std_linux_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package conn
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/ipv6"
+)
+
+type batchReaderFunc func([]ipv6.Message, int) (int, error)
+
+func (f batchReaderFunc) ReadBatch(msgs []ipv6.Message, flags int) (int, error) {
+	return f(msgs, flags)
+}
+
+func TestStdNetBindReceiveCleansAllMessages(t *testing.T) {
+	bind := NewStdNetBind().(*StdNetBind)
+	msgs := make([]ipv6.Message, IdealBatchSize)
+	for i := range msgs {
+		msgs[i].Buffers = make(net.Buffers, 1)
+		msgs[i].OOB = make([]byte, 0, stickyControlSize+gsoControlSize)
+	}
+	bind.msgsPool = sync.Pool{
+		New: func() any {
+			return &msgs
+		},
+	}
+
+	wantErr := errors.New("stop after touching tail descriptor")
+	reader := batchReaderFunc(func(readMsgs []ipv6.Message, _ int) (int, error) {
+		if len(readMsgs) != IdealBatchSize/udpSegmentMaxDatagrams {
+			t.Fatalf("ReadBatch received %d messages, want %d", len(readMsgs), IdealBatchSize/udpSegmentMaxDatagrams)
+		}
+		msg := &readMsgs[len(readMsgs)-1]
+		msg.N = 23
+		msg.NN = 1
+		msg.Addr = &net.UDPAddr{}
+		msg.Flags = 1
+		msg.OOB = append(msg.OOB, 1)
+		return 0, wantErr
+	})
+
+	_, err := bind.receiveIP(
+		reader,
+		nil,
+		true,
+		[][]byte{make([]byte, 64)},
+		make([]int, 1),
+		make([]Endpoint, 1),
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("receiveIP error = %v, want %v", err, wantErr)
+	}
+
+	got := msgs[len(msgs)-1]
+	if got.N != 0 || got.NN != 0 || got.Addr != nil || got.Flags != 0 || len(got.OOB) != 0 {
+		t.Fatalf("tail message was not reset: %+v", got)
+	}
+}

--- a/polyamide/tun/tun_linux.go
+++ b/polyamide/tun/tun_linux.go
@@ -448,6 +448,30 @@ func handleVirtioRead(in []byte, bufs [][]byte, sizes []int, offset int) (int, e
 	return gsoSplit(in, hdr, bufs, sizes, offset, ipVersion == 6)
 }
 
+func (tun *NativeTun) readPacket(
+	bufs [][]byte,
+	sizes []int,
+	offset int,
+	read func([]byte) (int, error),
+) (int, error) {
+	readInto := bufs[0][offset:]
+	if tun.vnetHdr {
+		readInto = tun.readBuff[:]
+	}
+	n, err := read(readInto)
+	if errors.Is(err, syscall.EBADFD) {
+		err = os.ErrClosed
+	}
+	if err != nil {
+		return 0, err
+	}
+	if tun.vnetHdr {
+		return handleVirtioRead(readInto[:n], bufs, sizes, offset)
+	}
+	sizes[0] = n
+	return 1, nil
+}
+
 func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
 	tun.readOpMu.Lock()
 	defer tun.readOpMu.Unlock()
@@ -455,24 +479,42 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		readInto := bufs[0][offset:]
-		if tun.vnetHdr {
-			readInto = tun.readBuff[:]
-		}
-		n, err := tun.tunFile.Read(readInto)
-		if errors.Is(err, syscall.EBADFD) {
-			err = os.ErrClosed
-		}
-		if err != nil {
-			return 0, err
-		}
-		if tun.vnetHdr {
-			return handleVirtioRead(readInto[:n], bufs, sizes, offset)
-		} else {
-			sizes[0] = n
-			return 1, nil
-		}
 	}
+
+	count, err := tun.readPacket(bufs, sizes, offset, tun.tunFile.Read)
+	if err != nil {
+		return count, err
+	}
+
+	rawConn, err := tun.tunFile.SyscallConn()
+	if err != nil {
+		return count, err
+	}
+	var drainErr error
+	err = rawConn.Control(func(fd uintptr) {
+		for count < len(bufs) {
+			n, readErr := tun.readPacket(
+				bufs[count:],
+				sizes[count:],
+				offset,
+				func(buf []byte) (int, error) {
+					return unix.Read(int(fd), buf)
+				},
+			)
+			count += n
+			if errors.Is(readErr, syscall.EAGAIN) || errors.Is(readErr, syscall.EWOULDBLOCK) {
+				return
+			}
+			if readErr != nil {
+				drainErr = readErr
+				return
+			}
+		}
+	})
+	if err != nil {
+		return count, err
+	}
+	return count, drainErr
 }
 
 func (tun *NativeTun) Events() <-chan Event {

--- a/polyamide/tun/tun_linux.go
+++ b/polyamide/tun/tun_linux.go
@@ -511,6 +511,9 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 					return unix.Read(int(fd), buf)
 				},
 			)
+			if errors.Is(readErr, syscall.EINTR) {
+				continue
+			}
 			if tun.vnetHdr && errors.Is(readErr, ErrTooManySegments) {
 				// The frame is already consumed from the TUN device. Keep it
 				// in readBuff and split it into a fresh batch on the next Read.

--- a/polyamide/tun/tun_linux.go
+++ b/polyamide/tun/tun_linux.go
@@ -46,8 +46,9 @@ type NativeTun struct {
 	nameCache string    // name of interface
 	nameErr   error
 
-	readOpMu sync.Mutex                    // readOpMu guards readBuff
-	readBuff [virtioNetHdrLen + 65535]byte // if vnetHdr every read() is prefixed by virtioNetHdr
+	readOpMu       sync.Mutex                    // readOpMu guards readBuff and pendingReadLen
+	readBuff       [virtioNetHdrLen + 65535]byte // if vnetHdr every read() is prefixed by virtioNetHdr
+	pendingReadLen int                           // length of a virtio frame deferred to the next Read
 
 	writeOpMu   sync.Mutex // writeOpMu guards toWrite, tcpGROTable
 	toWrite     []int
@@ -453,7 +454,7 @@ func (tun *NativeTun) readPacket(
 	sizes []int,
 	offset int,
 	read func([]byte) (int, error),
-) (int, error) {
+) (int, int, error) {
 	readInto := bufs[0][offset:]
 	if tun.vnetHdr {
 		readInto = tun.readBuff[:]
@@ -463,13 +464,14 @@ func (tun *NativeTun) readPacket(
 		err = os.ErrClosed
 	}
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if tun.vnetHdr {
-		return handleVirtioRead(readInto[:n], bufs, sizes, offset)
+		count, err := handleVirtioRead(readInto[:n], bufs, sizes, offset)
+		return count, n, err
 	}
 	sizes[0] = n
-	return 1, nil
+	return 1, n, nil
 }
 
 func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
@@ -481,7 +483,15 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 	default:
 	}
 
-	count, err := tun.readPacket(bufs, sizes, offset, tun.tunFile.Read)
+	var count int
+	var err error
+	if tun.pendingReadLen > 0 {
+		pendingReadLen := tun.pendingReadLen
+		tun.pendingReadLen = 0
+		count, err = handleVirtioRead(tun.readBuff[:pendingReadLen], bufs, sizes, offset)
+	} else {
+		count, _, err = tun.readPacket(bufs, sizes, offset, tun.tunFile.Read)
+	}
 	if err != nil {
 		return count, err
 	}
@@ -493,7 +503,7 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 	var drainErr error
 	err = rawConn.Control(func(fd uintptr) {
 		for count < len(bufs) {
-			n, readErr := tun.readPacket(
+			n, readLen, readErr := tun.readPacket(
 				bufs[count:],
 				sizes[count:],
 				offset,
@@ -501,6 +511,12 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 					return unix.Read(int(fd), buf)
 				},
 			)
+			if tun.vnetHdr && errors.Is(readErr, ErrTooManySegments) {
+				// The frame is already consumed from the TUN device. Keep it
+				// in readBuff and split it into a fresh batch on the next Read.
+				tun.pendingReadLen = readLen
+				return
+			}
 			count += n
 			if errors.Is(readErr, syscall.EAGAIN) || errors.Is(readErr, syscall.EWOULDBLOCK) {
 				return

--- a/polyamide/tun/tun_linux_test.go
+++ b/polyamide/tun/tun_linux_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package tun
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNativeTunReadDrainsAvailablePackets(t *testing.T) {
+	for _, packetCount := range []int{1, 3} {
+		t.Run(strconv.Itoa(packetCount), func(t *testing.T) {
+			fds, err := unix.Socketpair(
+				unix.AF_UNIX,
+				unix.SOCK_DGRAM|unix.SOCK_NONBLOCK|unix.SOCK_CLOEXEC,
+				0,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			reader := os.NewFile(uintptr(fds[0]), "tun-read-test")
+			t.Cleanup(func() {
+				reader.Close()
+				unix.Close(fds[1])
+			})
+
+			wantPackets := make([][]byte, packetCount)
+			for i := range packetCount {
+				wantPackets[i] = []byte{byte(i + 1), byte(i + 11)}
+				if _, err := unix.Write(fds[1], wantPackets[i]); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			const offset = 4
+			bufs := make([][]byte, 8)
+			sizes := make([]int, len(bufs))
+			for i := range bufs {
+				bufs[i] = make([]byte, 64)
+			}
+			tun := &NativeTun{
+				tunFile: reader,
+				errors:  make(chan error),
+			}
+
+			count, err := tun.Read(bufs, sizes, offset)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if count != packetCount {
+				t.Fatalf("Read returned %d packets, want %d", count, packetCount)
+			}
+			for i, want := range wantPackets {
+				if sizes[i] != len(want) {
+					t.Errorf("sizes[%d] = %d, want %d", i, sizes[i], len(want))
+				}
+				if got := bufs[i][offset : offset+sizes[i]]; !bytes.Equal(got, want) {
+					t.Errorf("packet %d = %v, want %v", i, got, want)
+				}
+			}
+		})
+	}
+}

--- a/polyamide/tun/tun_linux_test.go
+++ b/polyamide/tun/tun_linux_test.go
@@ -65,3 +65,77 @@ func TestNativeTunReadDrainsAvailablePackets(t *testing.T) {
 		})
 	}
 }
+
+func TestNativeTunReadDefersVirtioFrameThatExceedsRemainingBatch(t *testing.T) {
+	fds, err := unix.Socketpair(
+		unix.AF_UNIX,
+		unix.SOCK_DGRAM|unix.SOCK_NONBLOCK|unix.SOCK_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := os.NewFile(uintptr(fds[0]), "tun-virtio-read-test")
+	t.Cleanup(func() {
+		reader.Close()
+		unix.Close(fds[1])
+	})
+
+	singlePacket := udp4Packet(ip4PortA, ip4PortB, 16)
+	if err := (&virtioNetHdr{}).encode(singlePacket); err != nil {
+		t.Fatal(err)
+	}
+	segmentedPacket := udp4Packet(ip4PortA, ip4PortB, 200)
+	segmentedHeader := virtioNetHdr{
+		flags:      unix.VIRTIO_NET_HDR_F_NEEDS_CSUM,
+		gsoType:    unix.VIRTIO_NET_HDR_GSO_UDP_L4,
+		gsoSize:    100,
+		hdrLen:     28,
+		csumStart:  20,
+		csumOffset: 6,
+	}
+	if err := segmentedHeader.encode(segmentedPacket); err != nil {
+		t.Fatal(err)
+	}
+	for _, packet := range [][]byte{singlePacket, segmentedPacket} {
+		if _, err := unix.Write(fds[1], packet); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const outputOffset = 4
+	bufs := make([][]byte, 2)
+	sizes := make([]int, len(bufs))
+	for i := range bufs {
+		bufs[i] = make([]byte, 256)
+	}
+	tun := &NativeTun{
+		tunFile: reader,
+		errors:  make(chan error),
+		vnetHdr: true,
+	}
+
+	count, err := tun.Read(bufs, sizes, outputOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("first Read returned %d packets, want 1", count)
+	}
+	if sizes[0] != len(singlePacket)-virtioNetHdrLen {
+		t.Fatalf("first packet size = %d, want %d", sizes[0], len(singlePacket)-virtioNetHdrLen)
+	}
+
+	count, err = tun.Read(bufs, sizes, outputOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("second Read returned %d packets, want 2", count)
+	}
+	for i, wantSize := range []int{128, 128} {
+		if sizes[i] != wantSize {
+			t.Errorf("sizes[%d] = %d, want %d", i, sizes[i], wantSize)
+		}
+	}
+}

--- a/polyamide/tun/tun_linux_test.go
+++ b/polyamide/tun/tun_linux_test.go
@@ -97,13 +97,27 @@ func TestNativeTunReadDefersVirtioFrameThatExceedsRemainingBatch(t *testing.T) {
 	if err := segmentedHeader.encode(segmentedPacket); err != nil {
 		t.Fatal(err)
 	}
+
+	const outputOffset = 4
+	wantBufs := make([][]byte, 2)
+	wantSizes := make([]int, len(wantBufs))
+	for i := range wantBufs {
+		wantBufs[i] = make([]byte, 256)
+	}
+	wantCount, err := handleVirtioRead(bytes.Clone(segmentedPacket), wantBufs, wantSizes, outputOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wantCount != len(wantBufs) {
+		t.Fatalf("direct virtio split returned %d packets, want %d", wantCount, len(wantBufs))
+	}
+
 	for _, packet := range [][]byte{singlePacket, segmentedPacket} {
 		if _, err := unix.Write(fds[1], packet); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	const outputOffset = 4
 	bufs := make([][]byte, 2)
 	sizes := make([]int, len(bufs))
 	for i := range bufs {
@@ -133,9 +147,15 @@ func TestNativeTunReadDefersVirtioFrameThatExceedsRemainingBatch(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("second Read returned %d packets, want 2", count)
 	}
-	for i, wantSize := range []int{128, 128} {
-		if sizes[i] != wantSize {
-			t.Errorf("sizes[%d] = %d, want %d", i, sizes[i], wantSize)
+	for i := range wantBufs {
+		if sizes[i] != wantSizes[i] {
+			t.Errorf("sizes[%d] = %d, want %d", i, sizes[i], wantSizes[i])
+			continue
+		}
+		got := bufs[i][outputOffset : outputOffset+sizes[i]]
+		want := wantBufs[i][outputOffset : outputOffset+wantSizes[i]]
+		if !bytes.Equal(got, want) {
+			t.Errorf("packet %d differs after being deferred", i)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Improve Linux packet-rate performance by preserving batches across the TUN and
UDP send paths.

The Linux TUN reader now blocks for the first packet and then drains immediately
available packets until the caller's batch is full or the descriptor returns
`EAGAIN`. This introduces no batching timer.

The standard network bind also resets only the pooled message descriptors that
were used by the current operation instead of walking all 128 entries after
every send.

## Changes

- Refactor Linux TUN packet decoding into a reusable helper.
- Block normally for the first TUN packet.
- Drain additional immediately available packets with nonblocking reads.
- Bound each drain to the caller-provided batch capacity.
- Coordinate raw descriptor access through `RawConn.Control` so the descriptor
  remains valid across concurrent close operations.
- Preserve virtio-net GSO splitting, offsets, packet ordering, and partial-batch
  error behavior.
- Add a Linux socket-based test covering one-packet and multi-packet reads.
- Reset only the message descriptors used by each standard-bind operation.
- Track the maximum number of descriptors touched across the UDP GSO fallback
  retry path.

## Performance

Tests ran over a gigabit Ethernet switch from Normandy, an x86_64 Debian laptop,
to Natanus, a Raspberry Pi 5 running Debian, using a direct Nylon route.

Each UDP workload used four iperf3 streams. Delivered throughput accounts for
reported packet loss.

| Workload | Baseline | Final candidate |
| --- | ---: | ---: |
| TCP, 4 streams | 844–882 Mbit/s | 877 Mbit/s |
| UDP, 1200-byte payload, 900 Mbit/s offered | 437–505 Mbit/s | 890–891 Mbit/s |
| UDP, 64-byte payload, 100 Mbit/s offered | 30.0–30.9 Mbit/s | 97.1–98.2 Mbit/s |
| UDP, 64-byte loss | 69–70% | 1.8–2.8% |

For the 64-byte workload, delivered throughput improved by approximately 221%.
Normal-packet UDP improved by approximately 89%. TCP remained within the
bracketing baseline range.

The changes were also tested separately:

- timer-free TUN draining raised 64-byte UDP delivery to approximately
  82–93 Mbit/s;
- limiting message cleanup to used descriptors raised it further to
  approximately 97–98 Mbit/s.

## Latency and CPU

The TUN drain has no timer: after the first blocking read it only consumes
packets already queued by the kernel.

Repeated idle probes remained in the same sub-millisecond range. Stable samples
had average RTTs around 0.5–0.7 ms, with no consistent candidate regression.

The baseline processed only about 30 Mbit/s of the offered small-packet traffic
and used roughly 30% of one CPU core. The optimized path processed approximately
87 Mbit/s during profiling and used roughly 88% of one core. CPU use therefore
scaled with useful delivered traffic rather than remaining idle while packets
were dropped.

The optimized profile showed:

- Linux syscalls as the primary remaining cost;
- the Linux TUN read path as the next packet-rate boundary;
- metrics overhead reduced from approximately 9.3% to 3.5%;
- pooled-message reset overhead absent from sampled CPU time;
- encryption remaining a minor cost.

Multiqueue TUN support may be useful beyond the tested packet rate, but it is
more invasive and is intentionally outside this PR.

## Validation

- Full `go test ./...` suite passes.
- `go test -race ./polyamide/tun` passes.
- Complete Windows amd64 cross-build passes.
- The focused Linux test verifies that one blocking read drains additional
  available packet boundaries without waiting for future packets.
- `git diff --check` passes.