### PR TITLE
refactor: make config pure, group tc fwd tables, tidy dns resolution state

### DIFF
--- a/core/entrypoint.go
+++ b/core/entrypoint.go
@@ -58,7 +58,12 @@ func readCentralConfig(centralPath, nodePath string, tunables *state.RouterTunab
 			return nil, fmt.Errorf("central.yaml not found and node.yaml has no dist config")
 		}
 
-		cfg, err := FetchConfig(nodeCfg.Dist.Url, nodeCfg.Dist.Key, tunables.MaxConfigSize)
+		cfg, err := fetchConfig(
+			nodeCfg.Dist.Url,
+			nodeCfg.Dist.Key,
+			tunables.MaxConfigSize,
+			state.NewDNSResolver(nodeCfg.DnsResolvers),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/core/ipc_handler.go
+++ b/core/ipc_handler.go
@@ -198,7 +198,7 @@ func buildNeighbours(n *Nylon, wgStats map[state.NyPublicKey]device.PeerStatus) 
 		eps := make([]*protocol.EndpointInfo, 0)
 		routes := make([]*protocol.NeighRoute, 0)
 		if neigh != nil {
-			eps = buildEndpoints(neigh)
+			eps = n.buildEndpoints(neigh)
 			routes = buildNeighRoutes(neigh)
 		}
 		stat := wgStats[cfg.PubKey]
@@ -215,16 +215,16 @@ func buildNeighbours(n *Nylon, wgStats map[state.NyPublicKey]device.PeerStatus) 
 	return neighbours
 }
 
-func buildEndpoints(neigh *state.Neighbour) []*protocol.EndpointInfo {
+func (n *Nylon) buildEndpoints(neigh *state.Neighbour) []*protocol.EndpointInfo {
 	eps := make([]*protocol.EndpointInfo, 0, len(neigh.Eps))
 	for _, ep := range neigh.Eps {
 		nep := ep.AsNylonEndpoint()
 		var resolved *string
-		if ap, err := nep.DynEP.Get(); err == nil {
+		if ap, err := n.EndpointResolver.Get(nep.Address); err == nil {
 			resolved = new(ap.String())
 		}
 		eps = append(eps, &protocol.EndpointInfo{
-			Address:         nep.DynEP.Value,
+			Address:         nep.Address,
 			Resolved:        resolved,
 			Active:          ep.IsActive(),
 			RemoteInit:      ep.IsRemote(),
@@ -255,13 +255,14 @@ func buildNeighRoutes(neigh *state.Neighbour) []*protocol.NeighRoute {
 
 func buildRouteTables(n *Nylon) *protocol.RouteTables {
 	tables := &protocol.RouteTables{}
+	forwarding := n.router.Tables.Load()
 	for _, route := range n.RouterState.Routes {
 		tables.Selected = append(tables.Selected, selRouteProto(route))
 	}
 	slices.SortFunc(tables.Selected, func(a, b *protocol.SelRoute) int {
 		return comparePubRoute(a.PubRoute, b.PubRoute)
 	})
-	for prefix, route := range n.router.ForwardTable.Load().All() {
+	for prefix, route := range forwarding.Forward.All() {
 		tables.Forward = append(tables.Forward, &protocol.RouteTableEntry{
 			Prefix:    prefix.String(),
 			Nh:        string(route.Nh),
@@ -269,7 +270,7 @@ func buildRouteTables(n *Nylon) *protocol.RouteTables {
 		})
 	}
 	sortRouteTableEntries(tables.Forward)
-	for prefix, route := range n.router.ExitTable.Load().All() {
+	for prefix, route := range forwarding.Exit.All() {
 		tables.Exit = append(tables.Exit, &protocol.RouteTableEntry{
 			Prefix:    prefix.String(),
 			Nh:        string(route.Nh),

--- a/core/nylon.go
+++ b/core/nylon.go
@@ -21,7 +21,6 @@ import (
 	"github.com/encodeous/nylon/polyamide/tun"
 	"github.com/encodeous/nylon/state"
 	"github.com/encodeous/tint"
-	"github.com/gaissmai/bart"
 	"github.com/jellydator/ttlcache/v3"
 	slogmulti "github.com/samber/slog-multi"
 )
@@ -35,20 +34,22 @@ type Nylon struct {
 
 	// state
 	state.ConfigState
-	RouterState   *state.RouterState
-	AppliedSystem AppliedSystemState
-	PingBuf       *ttlcache.Cache[uint64, EpPing]
-	PeerMap       atomic.Pointer[map[state.NyPublicKey]state.NodeId]
+	RouterState      *state.RouterState
+	AppliedSystem    AppliedSystemState
+	PingBuf          *ttlcache.Cache[uint64, EpPing]
+	PeerMap          atomic.Pointer[map[state.NyPublicKey]state.NodeId]
+	DNSResolver      *state.DNSResolver
+	EndpointResolver *state.EndpointResolver
+	prefixHealth     map[netip.Prefix]advertisedPrefixHealth
 
 	router struct {
 		LastStarvationRequest time.Time
 		IO                    map[state.NodeId]*IOPending
 
-		// ForwardTable contains the full routing table
-		ForwardTable atomic.Pointer[bart.Table[RouteTableEntry]]
-		// ExitTable contains only routes to services hosted on this node
-		ExitTable atomic.Pointer[bart.Table[RouteTableEntry]]
-		log       *slog.Logger
+		// Tables is published atomically so forwarding and exit routes always
+		// belong to the same state generation.
+		Tables atomic.Pointer[ForwardingTables]
+		log    *slog.Logger
 	}
 
 	// runtime/application
@@ -81,6 +82,13 @@ func NewNylon(ccfg state.CentralCfg, ncfg state.LocalCfg, logLevel slog.Level, c
 	ctx, cancel := context.WithCancelCause(context.Background())
 
 	dispatch := make(chan func() error, 128)
+	err, runtimeCfg := ccfg.Clone()
+	if err != nil {
+		cancel(err)
+		return nil, err
+	}
+	state.ExpandCentralConfig(runtimeCfg)
+	dnsResolver := state.NewDNSResolver(ncfg.DnsResolvers)
 
 	var rt state.RouterTunables
 	if tunables != nil {
@@ -135,20 +143,22 @@ func NewNylon(ccfg state.CentralCfg, ncfg state.LocalCfg, logLevel slog.Level, c
 		RouterTunables: rt,
 		NylonOptions:   opts,
 		ConfigState: state.ConfigState{
-			CentralCfg: ccfg,
+			CentralCfg: *runtimeCfg,
 			LocalCfg:   ncfg,
 		},
-		Context:         ctx,
-		Cancel:          cancel,
-		DispatchChannel: dispatch,
-		Log:             logger,
-		ConfigPath:      configPath,
-		AuxConfig:       aux,
+		Context:          ctx,
+		Cancel:           cancel,
+		DispatchChannel:  dispatch,
+		Log:              logger,
+		ConfigPath:       configPath,
+		AuxConfig:        aux,
+		DNSResolver:      dnsResolver,
+		EndpointResolver: state.NewEndpointResolver(dnsResolver),
 	}
 
 	n.Log.Info("init modules")
 
-	err := n.Init()
+	err = n.Init()
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +176,6 @@ func (n *Nylon) Init() error {
 	if err != nil {
 		return err
 	}
-
-	state.SetResolvers(n.DnsResolvers)
 
 	if n.AppliedSystem.Peers == nil {
 		n.AppliedSystem.Peers = make(map[state.NodeId]state.NyPublicKey)
@@ -199,16 +207,20 @@ func (n *Nylon) Init() error {
 	}, n.ProbeDelay)
 	n.RepeatTask(func() error {
 		// refresh dynamic endpoints
+		seen := make(map[string]struct{})
 		for _, neigh := range n.RouterState.Neighbours {
 			for _, ep := range neigh.Eps {
-				if nep, ok := ep.(*state.NylonEndpoint); ok {
-					go func() {
-						_, err := nep.DynEP.Refresh(n.EndpointResolveExpiry)
-						if err != nil {
-							n.Log.Debug("failed to resolve endpoint", "ep", nep.DynEP.Value, "err", err.Error())
-						}
-					}()
+				address := ep.AsNylonEndpoint().Address
+				if _, ok := seen[address]; ok {
+					continue
 				}
+				seen[address] = struct{}{}
+				go func() {
+					_, err := n.EndpointResolver.Resolve(address, n.EndpointResolveExpiry)
+					if err != nil {
+						n.Log.Debug("failed to resolve endpoint", "ep", address, "err", err.Error())
+					}
+				}()
 			}
 		}
 		return nil
@@ -220,7 +232,7 @@ func (n *Nylon) Init() error {
 		return n.probeNew()
 	}, n.ProbeDiscoveryDelay)
 
-	n.startAdvertisedPrefixHealth()
+	n.reconcileAdvertisedPrefixes(&n.CentralCfg)
 
 	err = n.initPassiveClient()
 	if err != nil {
@@ -311,8 +323,8 @@ endLoop:
 
 func (n *Nylon) Cleanup() error {
 	n.PingBuf.Stop()
-	for _, ph := range n.GetNode(n.LocalCfg.Id).Prefixes {
-		ph.Stop()
+	for _, health := range n.prefixHealth {
+		health.monitor.Stop()
 	}
 
 	n.CleanupRouter()

--- a/core/nylon_apply.go
+++ b/core/nylon_apply.go
@@ -5,7 +5,6 @@ import (
 	"net/netip"
 	"reflect"
 	"slices"
-	"time"
 
 	"github.com/encodeous/nylon/state"
 )
@@ -20,36 +19,53 @@ const (
 )
 
 func (n *Nylon) ApplyCentralConfig(cfg *state.CentralCfg) (ApplyResult, error) {
-	err, next := cfg.Clone()
+	candidate, err := normalizeCentralConfig(cfg)
 	if err != nil {
 		return ApplyRejected, err
 	}
-	state.ExpandCentralConfig(next)
-	if err := state.CentralConfigValidator(next); err != nil {
-		return ApplyRejected, err
-	}
-	if !next.IsRouter(n.LocalCfg.Id) {
+	if !candidate.IsRouter(n.LocalCfg.Id) {
 		return ApplyRestartRequired, errors.New("local node is not a router in the new central config")
 	}
-	if reflect.DeepEqual(n.CentralCfg, next) {
-		return ApplyNoop, nil
+	sameConfig := reflect.DeepEqual(&n.CentralCfg, candidate)
+	if sameConfig {
+		// A previous apply may have committed the desired config while external
+		// reconciliation was incomplete. Make an explicit retry useful even
+		// before the periodic reconciler runs again.
+		return ApplyNoop, n.SyncApplicationState()
 	}
-
-	if err := n.reconcileRouterState(next); err != nil {
+	if err := n.reconcileRouterState(candidate); err != nil {
 		return ApplyRejected, err
 	}
-	n.reconcileAdvertisedPrefixes(next)
-	n.CentralCfg = *next
+	n.reconcileAdvertisedPrefixes(candidate)
+	n.CentralCfg = *candidate
 
+	// From here on the candidate is the accepted desired state. Failures while
+	// converging WireGuard or OS state are retryable and must not describe the
+	// already-committed config as rejected.
+	return ApplyApplied, n.SyncApplicationState()
+}
+
+func (n *Nylon) SyncApplicationState() error {
+	if n.Device == nil {
+		return nil
+	}
 	if err := n.SyncWireGuard(); err != nil {
-		return ApplyRejected, err
-	}
-	if err := n.SyncSystemState(); err != nil {
-		return ApplyRejected, err
+		return err
 	}
 	ComputeRoutes(n.RouterState, n)
+	return n.SyncSystemState()
+}
 
-	return ApplyApplied, nil
+func normalizeCentralConfig(cfg *state.CentralCfg) (*state.CentralCfg, error) {
+	err, normalized := cfg.Clone()
+	if err != nil {
+		return nil, err
+	}
+	state.ExpandCentralConfig(normalized)
+	if err := state.CentralConfigValidator(normalized); err != nil {
+		return nil, err
+	}
+	return normalized, nil
 }
 
 func (n *Nylon) reconcileRouterState(next *state.CentralCfg) error {
@@ -94,6 +110,15 @@ func (n *Nylon) reconcileRouterState(next *state.CentralCfg) error {
 		neighs = append(neighs, stNeigh)
 	}
 	n.RouterState.Neighbours = neighs
+	if n.EndpointResolver != nil {
+		addresses := make(map[string]struct{})
+		for _, neigh := range neighs {
+			for _, endpoint := range neigh.Eps {
+				addresses[endpoint.AsNylonEndpoint().Address] = struct{}{}
+			}
+		}
+		n.EndpointResolver.Retain(addresses)
+	}
 
 	// rebuild pubkey to peer's id mapping
 	pubkeyMap := make(map[state.NyPublicKey]state.NodeId)
@@ -107,10 +132,10 @@ func (n *Nylon) reconcileRouterState(next *state.CentralCfg) error {
 	return nil
 }
 
-func reconcileConfiguredEndpoints(neigh *state.Neighbour, desired []*state.DynamicEndpoint, t *state.RouterTunables) {
-	desiredByValue := make(map[string]*state.DynamicEndpoint, len(desired))
-	for _, ep := range desired {
-		desiredByValue[ep.Value] = ep
+func reconcileConfiguredEndpoints(neigh *state.Neighbour, desired []string, t *state.RouterTunables) {
+	desiredAddresses := make(map[string]struct{}, len(desired))
+	for _, address := range desired {
+		desiredAddresses[address] = struct{}{}
 	}
 
 	eps := make([]state.Endpoint, 0, len(neigh.Eps)+len(desired))
@@ -122,77 +147,16 @@ func reconcileConfiguredEndpoints(neigh *state.Neighbour, desired []*state.Dynam
 			continue
 		}
 		// only keep if desired
-		if desiredEp, ok := desiredByValue[nep.DynEP.Value]; ok {
+		if _, ok := desiredAddresses[nep.Address]; ok {
 			eps = append(eps, ep)
-			seen[desiredEp.Value] = struct{}{}
+			seen[nep.Address] = struct{}{}
 		}
 	}
-	for _, ep := range desired {
-		if _, ok := seen[ep.Value]; ok {
+	for _, address := range desired {
+		if _, ok := seen[address]; ok {
 			continue
 		}
-		eps = append(eps, state.NewEndpoint(ep, false, nil, t))
+		eps = append(eps, state.NewEndpoint(address, false, nil, t))
 	}
 	neigh.Eps = eps
 }
-
-func (n *Nylon) reconcileAdvertisedPrefixes(next *state.CentralCfg) {
-	currentLocal := make(map[netip.Prefix]state.PrefixHealthWrapper)
-	if cur := n.CentralCfg.TryGetNode(n.LocalCfg.Id); cur != nil {
-		for _, prefix := range cur.Prefixes {
-			currentLocal[prefix.GetPrefix()] = prefix
-		}
-	}
-	nextNode := next.TryGetNode(n.LocalCfg.Id)
-	if nextNode == nil {
-		return
-	}
-
-	desiredLocal := make(map[netip.Prefix]int)
-	for i, prefix := range nextNode.Prefixes {
-		desiredLocal[prefix.GetPrefix()] = i
-	}
-
-	for prefix, adv := range n.RouterState.Advertised {
-		if adv.NodeId != n.LocalCfg.Id {
-			continue
-		}
-		if _, ok := desiredLocal[prefix]; !ok {
-			if old, ok := currentLocal[prefix]; ok {
-				old.Stop()
-			}
-			delete(n.RouterState.Advertised, prefix)
-		}
-	}
-
-	for prefix, index := range desiredLocal {
-		desired := nextNode.Prefixes[index]
-		if current, ok := currentLocal[prefix]; ok && current.SameConfig(desired, &n.RouterTunables) {
-			desired = current
-			nextNode.Prefixes[index] = current
-		} else {
-			if current, ok := currentLocal[prefix]; ok {
-				current.Stop()
-			}
-			n.Log.Debug("starting prefix healthcheck", "prefix", prefix)
-			desired.Start(n.Log, &n.RouterTunables)
-		}
-		n.RouterState.Advertised[prefix] = state.Advertisement{
-			NodeId:   n.LocalCfg.Id,
-			Expiry:   maxConfigTime,
-			MetricFn: desired.GetMetric,
-			ExpiryFn: func() {
-				desired.Stop()
-			},
-		}
-	}
-}
-
-func (n *Nylon) startAdvertisedPrefixHealth() {
-	for _, ph := range n.GetNode(n.LocalCfg.Id).Prefixes {
-		n.Log.Debug("starting prefix healthcheck", "prefix", ph.GetPrefix())
-		ph.Start(n.Log, &n.RouterTunables)
-	}
-}
-
-var maxConfigTime = time.Unix(1<<63-62135596801, 999999999)

--- a/core/nylon_apply_test.go
+++ b/core/nylon_apply_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/encodeous/nylon/polyamide/device"
 	"github.com/encodeous/nylon/state"
+	"github.com/gaissmai/bart"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +22,7 @@ func TestReconcileAdvertisedPrefixesStartsChangedPrefixHealth(t *testing.T) {
 	n.RouterState.Advertised[prefix] = state.Advertisement{
 		NodeId:   n.LocalCfg.Id,
 		Expiry:   maxConfigTime,
-		MetricFn: oldPrefix.GetMetric,
+		MetricFn: func() uint32 { return 0 },
 	}
 
 	delay := time.Millisecond
@@ -33,7 +35,7 @@ func TestReconcileAdvertisedPrefixesStartsChangedPrefixHealth(t *testing.T) {
 	})
 
 	n.reconcileAdvertisedPrefixes(&next)
-	t.Cleanup(next.Routers[0].Prefixes[0].Stop)
+	t.Cleanup(n.prefixHealth[prefix].monitor.Stop)
 
 	assert.Equal(t, state.INF, n.RouterState.Advertised[prefix].MetricFn())
 }
@@ -47,7 +49,7 @@ func TestReconcileAdvertisedPrefixesStartsChangedPingPrefixHealth(t *testing.T) 
 	n.RouterState.Advertised[prefix] = state.Advertisement{
 		NodeId:   n.LocalCfg.Id,
 		Expiry:   maxConfigTime,
-		MetricFn: oldPrefix.GetMetric,
+		MetricFn: func() uint32 { return 0 },
 	}
 
 	delay := 100 * time.Millisecond
@@ -60,12 +62,12 @@ func TestReconcileAdvertisedPrefixesStartsChangedPingPrefixHealth(t *testing.T) 
 	})
 
 	n.reconcileAdvertisedPrefixes(&next)
-	t.Cleanup(next.Routers[0].Prefixes[0].Stop)
+	t.Cleanup(n.prefixHealth[prefix].monitor.Stop)
 
 	assert.Equal(t, state.INF, n.RouterState.Advertised[prefix].MetricFn())
 }
 
-func TestReconcileAdvertisedPrefixesReusesUnchangedRunningPrefixHealth(t *testing.T) {
+func TestReconcileAdvertisedPrefixesReusesUnchangedMonitor(t *testing.T) {
 	prefix := netip.MustParsePrefix("fd00::53/128")
 	delay := time.Millisecond
 	current := state.PrefixHealthWrapper{
@@ -76,13 +78,19 @@ func TestReconcileAdvertisedPrefixesReusesUnchangedRunningPrefixHealth(t *testin
 		},
 	}
 	n := testNylonWithPrefixes(current)
-	current.Start(n.Log, &n.RouterTunables)
-	t.Cleanup(current.Stop)
+	monitor := current.NewMonitor(n.Log, &n.RouterTunables, n.DNSResolver)
+	t.Cleanup(monitor.Stop)
+	n.prefixHealth = map[netip.Prefix]advertisedPrefixHealth{
+		prefix: {
+			config:  current,
+			monitor: monitor,
+		},
+	}
 	n.RouterState.Advertised[prefix] = state.Advertisement{
 		NodeId:   n.LocalCfg.Id,
 		Expiry:   maxConfigTime,
-		MetricFn: current.GetMetric,
-		ExpiryFn: current.Stop,
+		MetricFn: monitor.GetMetric,
+		ExpiryFn: monitor.Stop,
 	}
 
 	next := testCentralConfig(n.LocalCfg.Id, state.PrefixHealthWrapper{
@@ -95,8 +103,57 @@ func TestReconcileAdvertisedPrefixesReusesUnchangedRunningPrefixHealth(t *testin
 
 	n.reconcileAdvertisedPrefixes(&next)
 
-	assert.Same(t, current.PrefixHealth, next.Routers[0].Prefixes[0].PrefixHealth)
+	assert.Equal(t, monitor, n.prefixHealth[prefix].monitor)
 	assert.Equal(t, state.INF, n.RouterState.Advertised[prefix].MetricFn())
+}
+
+func TestRebindForwardingPeersUpdatesUnchangedNextHop(t *testing.T) {
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+	nextHop := state.NodeId("next")
+	oldPeer := new(device.Peer)
+	newPeer := new(device.Peer)
+	forward := new(bart.Table[RouteTableEntry])
+	forward.Insert(prefix, RouteTableEntry{Nh: nextHop, Peer: oldPeer})
+
+	rebound, changed := rebindRouteTablePeers(forward, map[state.NodeId]*device.Peer{
+		nextHop: newPeer,
+	})
+
+	assert.True(t, changed)
+	forwardEntry, ok := rebound.Lookup(prefix.Addr())
+	if assert.True(t, ok) {
+		assert.Same(t, newPeer, forwardEntry.Peer)
+		assert.Equal(t, nextHop, forwardEntry.Nh)
+	}
+	oldEntry, ok := forward.Lookup(prefix.Addr())
+	if assert.True(t, ok) {
+		assert.Same(t, oldPeer, oldEntry.Peer, "published forwarding snapshots must remain immutable")
+	}
+}
+
+func TestRebindForwardingPeersReusesUnchangedTable(t *testing.T) {
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+	nextHop := state.NodeId("next")
+	peer := new(device.Peer)
+	forward := new(bart.Table[RouteTableEntry])
+	forward.Insert(prefix, RouteTableEntry{Nh: nextHop, Peer: peer})
+
+	rebound, changed := rebindRouteTablePeers(forward, map[state.NodeId]*device.Peer{
+		nextHop: peer,
+	})
+
+	assert.False(t, changed)
+	assert.Same(t, forward, rebound)
+}
+
+func TestHandleNylonPacketDropsUnknownRetiredPeer(t *testing.T) {
+	n := &Nylon{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	peerMap := make(map[state.NyPublicKey]state.NodeId)
+	n.PeerMap.Store(&peerMap)
+
+	assert.NotPanics(t, func() {
+		n.handleNylonPacket(nil, nil, new(device.Peer))
+	})
 }
 
 func testNylonWithPrefixes(prefixes ...state.PrefixHealthWrapper) *Nylon {

--- a/core/nylon_distribution.go
+++ b/core/nylon_distribution.go
@@ -1,11 +1,9 @@
 package core
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,6 +15,10 @@ import (
 
 // fetches and unbundles central config from url
 func FetchConfig(repoStr string, key state.NyPublicKey, maxSize int64) (*state.CentralCfg, error) {
+	return fetchConfig(repoStr, key, maxSize, state.NewDNSResolver(nil))
+}
+
+func fetchConfig(repoStr string, key state.NyPublicKey, maxSize int64, resolver *state.DNSResolver) (*state.CentralCfg, error) {
 	repo, err := url.Parse(repoStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse repo URL %s: %w", repoStr, err)
@@ -32,24 +34,7 @@ func FetchConfig(repoStr string, key state.NyPublicKey, maxSize int64) (*state.C
 	} else if repo.Scheme == "http" || repo.Scheme == "https" {
 		client := &http.Client{
 			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
-					host, port, err := net.SplitHostPort(addr)
-					if err != nil {
-						return nil, err
-					}
-					addrs, err := state.ResolveName(ctx, host)
-					if err != nil {
-						return nil, err
-					}
-					for _, ip := range addrs {
-						var dialer net.Dialer
-						conn, err = dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-						if err == nil {
-							break
-						}
-					}
-					return
-				},
+				DialContext: resolver.DialContext,
 			},
 		}
 		res, err := client.Get(repo.String())
@@ -85,7 +70,7 @@ func checkForConfigUpdates(n *Nylon) error {
 	for _, repoStr := range repos {
 		go func(repo string) {
 			err := func() error {
-				config, err := FetchConfig(repo, key, n.MaxConfigSize)
+				config, err := fetchConfig(repo, key, n.MaxConfigSize, n.DNSResolver)
 				if err != nil {
 					return err
 				}
@@ -102,8 +87,11 @@ func checkForConfigUpdates(n *Nylon) error {
 					n.Log.Info("Found a new config update in repo", "repo", repo)
 					result, err := n.ApplyCentralConfig(config)
 					if err != nil {
-						n.Log.Error("failed to apply central config update", "repo", repo, "result", result, "err", err)
-						return nil
+						if result != ApplyApplied {
+							n.Log.Error("failed to apply central config update", "repo", repo, "result", result, "err", err)
+							return nil
+						}
+						n.Log.Warn("central config applied with incomplete runtime reconciliation; will retry", "repo", repo, "err", err)
 					}
 					if n.ConfigPath != "" {
 						bytes, err := yaml.Marshal(config)

--- a/core/nylon_endpoints.go
+++ b/core/nylon_endpoints.go
@@ -27,7 +27,7 @@ func (n *Nylon) sendEndpointProbes(peer state.NodeId, timeout time.Duration) ([]
 	}
 	eps := slices.Clone(neigh.Eps)
 	slices.SortFunc(eps, func(a, b state.Endpoint) int {
-		return cmp.Compare(a.AsNylonEndpoint().DynEP.Value, b.AsNylonEndpoint().DynEP.Value)
+		return cmp.Compare(a.AsNylonEndpoint().Address, b.AsNylonEndpoint().Address)
 	})
 	probes := make([]Future[*protocol.EndpointProbeResult], 0, len(eps))
 	for _, ep := range eps {
@@ -43,7 +43,7 @@ func (n *Nylon) Probe(node state.NodeId, ep *state.NylonEndpoint) error {
 }
 
 func (n *Nylon) sendEndpointProbe(node state.NodeId, ep *state.NylonEndpoint, timeout time.Duration) (Future[*protocol.EndpointProbeResult], error) {
-	address := ep.DynEP.Value
+	address := ep.Address
 	resolved := ""
 	resultFuture, completeResult := NewFuture[*protocol.EndpointProbeResult]()
 	completeEndpoint := func(status protocol.EndpointProbeStatus, latency time.Duration, err error) {
@@ -66,7 +66,7 @@ func (n *Nylon) sendEndpointProbe(node state.NodeId, ep *state.NylonEndpoint, ti
 	if peer == nil {
 		return fail(protocol.EndpointProbeStatus_ENDPOINT_PROBE_SEND_ERROR, fmt.Errorf("wireguard peer %q is not configured", node))
 	}
-	nep, err := ep.GetWgEndpoint(n.Device)
+	nep, err := ep.GetWgEndpoint(n.Device, n.EndpointResolver)
 	if err != nil {
 		return fail(protocol.EndpointProbeStatus_ENDPOINT_PROBE_RESOLVE_ERROR, err)
 	}
@@ -152,7 +152,7 @@ func handleProbePing(n *Nylon, node state.NodeId, wgEndpoint conn.Endpoint) {
 	for _, neigh := range n.RouterState.Neighbours {
 		for _, dep := range neigh.Eps {
 			dep := dep.AsNylonEndpoint()
-			ap, err := dep.DynEP.Get()
+			ap, err := n.EndpointResolver.Get(dep.Address)
 			if err == nil && ap == wgEndpoint.DstIPPort() && neigh.Id == node {
 				// we have a link
 
@@ -176,7 +176,7 @@ func handleProbePing(n *Nylon, node state.NodeId, wgEndpoint conn.Endpoint) {
 	// create a new link if we dont have a link
 	for _, neigh := range n.RouterState.Neighbours {
 		if neigh.Id == node {
-			newEp := state.NewEndpoint(state.NewDynamicEndpoint(wgEndpoint.DstIPPort().String()), true, wgEndpoint, &n.RouterTunables)
+			newEp := state.NewEndpoint(wgEndpoint.DstIPPort().String(), true, wgEndpoint, &n.RouterTunables)
 			newEp.Renew()
 			neigh.Eps = append(neigh.Eps, newEp)
 			// push route update to improve convergence time
@@ -205,7 +205,7 @@ func handleProbePong(n *Nylon, node state.NodeId, token uint64, ep conn.Endpoint
 	for _, neigh := range n.RouterState.Neighbours {
 		for _, dep := range neigh.Eps {
 			dpLink := dep.AsNylonEndpoint()
-			ap, err := dpLink.DynEP.Get()
+			ap, err := n.EndpointResolver.Get(dpLink.Address)
 			if err == nil && ap == ep.DstIPPort() && neigh.Id == node {
 				// we have a link
 				if n.DBG_log_probe {
@@ -251,27 +251,22 @@ func (n *Nylon) probeNew() error {
 			continue
 		}
 		cfg := n.GetRouter(peer)
-		// assumption: we don't need to connect to the same endpoint again within the scope of the same node
-		for _, ep := range cfg.Endpoints {
-			ap, err := ep.Get()
-			if err != nil {
-				continue
-			}
+		for _, address := range cfg.Endpoints {
 			idx := slices.IndexFunc(neigh.Eps, func(link state.Endpoint) bool {
-				lap, err := link.AsNylonEndpoint().DynEP.Get()
-				if err != nil {
-					return false
-				}
-				return !link.IsRemote() && lap == ap
+				return !link.IsRemote() && link.AsNylonEndpoint().Address == address
 			})
 			if idx == -1 {
 				// add the link to the neighbour
-				dpl := state.NewEndpoint(ep, false, nil, &n.RouterTunables)
+				dpl := state.NewEndpoint(address, false, nil, &n.RouterTunables)
 				neigh.Eps = append(neigh.Eps, dpl)
-				err := n.Probe(peer, dpl)
-				if err != nil {
-					//n.Log.Debug("discovery probe failed", "err", err.Error())
-				}
+				idx = len(neigh.Eps) - 1
+			}
+			dpl := neigh.Eps[idx].AsNylonEndpoint()
+			if _, err := n.EndpointResolver.Get(dpl.Address); err != nil {
+				continue
+			}
+			if err := n.Probe(peer, dpl); err != nil {
+				//n.Log.Debug("discovery probe failed", "err", err.Error())
 			}
 		}
 	}

--- a/core/nylon_gc.go
+++ b/core/nylon_gc.go
@@ -1,6 +1,16 @@
 package core
 
 func nylonGc(n *Nylon) error {
+	activeAddresses := make(map[string]struct{})
+	for _, neigh := range n.RouterState.Neighbours {
+		for _, endpoint := range neigh.Eps {
+			link := endpoint.AsNylonEndpoint()
+			if link.IsActive() {
+				activeAddresses[link.Address] = struct{}{}
+			}
+		}
+	}
+
 	// scan for dead links
 	for _, neigh := range n.RouterState.Neighbours {
 		// filter dplinks
@@ -8,13 +18,15 @@ func nylonGc(n *Nylon) error {
 		for _, x := range neigh.Eps {
 			x := x.AsNylonEndpoint()
 			if !x.IsActive() {
-				x.DynEP.Clear()
+				if _, activeElsewhere := activeAddresses[x.Address]; !activeElsewhere {
+					n.EndpointResolver.Expire(x.Address)
+				}
 			}
 			if x.IsAlive() {
 				neigh.Eps[count] = x
 				count++
 			} else {
-				n.Log.Debug("removed dead endpoint", "ep", x.DynEP.String(), "to", neigh.Id)
+				n.Log.Debug("removed dead endpoint", "ep", x.Address, "to", neigh.Id)
 			}
 		}
 		neigh.Eps = neigh.Eps[:count]

--- a/core/nylon_prefix_health.go
+++ b/core/nylon_prefix_health.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"net/netip"
+	"time"
+
+	"github.com/encodeous/nylon/state"
+)
+
+// advertisedPrefixHealth binds immutable prefix configuration to the live
+// monitor used for a locally advertised prefix.
+type advertisedPrefixHealth struct {
+	config  state.PrefixHealthWrapper
+	monitor state.PrefixHealthMonitor
+}
+
+func (n *Nylon) reconcileAdvertisedPrefixes(next *state.CentralCfg) {
+	if n.prefixHealth == nil {
+		n.prefixHealth = make(map[netip.Prefix]advertisedPrefixHealth)
+	}
+	nextNode := next.TryGetNode(n.LocalCfg.Id)
+	if nextNode == nil {
+		return
+	}
+
+	desiredLocal := make(map[netip.Prefix]int)
+	for i, prefix := range nextNode.Prefixes {
+		desiredLocal[prefix.GetPrefix()] = i
+	}
+
+	for prefix, adv := range n.RouterState.Advertised {
+		if adv.NodeId != n.LocalCfg.Id {
+			continue
+		}
+		if _, ok := desiredLocal[prefix]; !ok {
+			if old, ok := n.prefixHealth[prefix]; ok {
+				old.monitor.Stop()
+				delete(n.prefixHealth, prefix)
+			}
+			delete(n.RouterState.Advertised, prefix)
+		}
+	}
+
+	for prefix, index := range desiredLocal {
+		config := nextNode.Prefixes[index]
+		var health advertisedPrefixHealth
+		if current, ok := n.prefixHealth[prefix]; ok && current.config.SameConfig(config, &n.RouterTunables) {
+			health = current
+		} else {
+			if current, ok := n.prefixHealth[prefix]; ok {
+				current.monitor.Stop()
+			}
+			n.Log.Debug("starting prefix healthcheck", "prefix", prefix)
+			health = advertisedPrefixHealth{
+				config:  config,
+				monitor: config.NewMonitor(n.Log, &n.RouterTunables, n.DNSResolver),
+			}
+			n.prefixHealth[prefix] = health
+		}
+		n.RouterState.Advertised[prefix] = state.Advertisement{
+			NodeId:   n.LocalCfg.Id,
+			Expiry:   maxConfigTime,
+			MetricFn: health.monitor.GetMetric,
+			ExpiryFn: func() {
+				health.monitor.Stop()
+			},
+		}
+	}
+}
+
+var maxConfigTime = time.Unix(1<<63-62135596801, 999999999)

--- a/core/nylon_tc.go
+++ b/core/nylon_tc.go
@@ -53,7 +53,7 @@ func (n *Nylon) InstallTC() {
 		})
 		// forward only outgoing packets based on the routing table
 		n.Device.InstallFilter(func(dev *device.Device, packet *device.TCElement) (device.TCAction, error) {
-			entry, ok := n.router.ForwardTable.Load().Lookup(packet.GetDst())
+			entry, ok := n.router.Tables.Load().Forward.Lookup(packet.GetDst())
 			if ok && !packet.Incoming() {
 				if entry.Blackhole {
 					return device.TcDrop, nil
@@ -69,7 +69,7 @@ func (n *Nylon) InstallTC() {
 	} else {
 		// forward packets based on the routing table
 		n.Device.InstallFilter(func(dev *device.Device, packet *device.TCElement) (device.TCAction, error) {
-			entry, ok := n.router.ForwardTable.Load().Lookup(packet.GetDst())
+			entry, ok := n.router.Tables.Load().Forward.Lookup(packet.GetDst())
 			if ok {
 				if entry.Blackhole {
 					return device.TcDrop, nil
@@ -107,7 +107,7 @@ func (n *Nylon) InstallTC() {
 
 	// bounce back packets destined for the current node
 	n.Device.InstallFilter(func(dev *device.Device, packet *device.TCElement) (device.TCAction, error) {
-		entry, ok := n.router.ExitTable.Load().Lookup(packet.GetDst())
+		entry, ok := n.router.Tables.Load().Exit.Lookup(packet.GetDst())
 		// we should only accept packets destined to us, but not our passive clients
 		if ok && entry.Nh == n.LocalCfg.Id {
 			if n.DBG_trace_tc {
@@ -161,6 +161,13 @@ func (n *Nylon) SendNylonBundle(pkt *protocol.TransportBundle, endpoint conn.End
 
 func (n *Nylon) handleNylonPacket(packet []byte, endpoint conn.Endpoint, peer *device.Peer) {
 	// we need to be careful here, since this function is called on the dataplane
+	defer func() {
+		err := recover()
+		if err != nil {
+			n.Log.Error("panic while handling poly socket", "err", err)
+		}
+	}()
+
 	bundle := &protocol.TransportBundle{}
 	err := proto.Unmarshal(packet, bundle)
 	if err != nil {
@@ -173,18 +180,17 @@ func (n *Nylon) handleNylonPacket(packet []byte, endpoint conn.Endpoint, peer *d
 	if nt == nil {
 		return // not loaded yet
 	}
+	if peer == nil {
+		n.Log.Debug("dropping nylon packet without an authenticated peer")
+		return
+	}
 	neigh, ok := (*nt)[state.NyPublicKey(peer.GetPublicKey())]
 	if !ok {
-		// this should not be possible
-		panic("impossible state, peer added, but not a node in the network")
+		// This is expected briefly while a peer is being retired after a config
+		// change. The packet was authenticated under an obsolete generation.
+		n.Log.Debug("dropping nylon packet from an unknown peer", "key", peer.GetPublicKey())
+		return
 	}
-
-	defer func() {
-		err := recover()
-		if err != nil {
-			n.Log.Error("panic while handling poly socket", "err", err)
-		}
-	}()
 
 	for _, pkt := range bundle.Packets {
 		switch pkt.Type.(type) {

--- a/core/nylon_wireguard.go
+++ b/core/nylon_wireguard.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"cmp"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"net/netip"
 	"runtime"
 	"slices"
 
@@ -89,9 +91,12 @@ listen_port=%d
 		}
 	}
 
-	// init wireguard related tasks
+	// schedule application state reconciliation
 	n.RepeatTask(func() error {
-		return n.UpdateWireGuard()
+		if err := n.SyncApplicationState(); err != nil {
+			n.Log.Warn("runtime reconciliation incomplete; will retry", "err", err)
+		}
+		return nil
 	}, n.ProbeDelay)
 
 	return nil
@@ -146,15 +151,9 @@ func (n *Nylon) SyncWireGuard() error {
 		desired[peer] = ncfg.PubKey
 	}
 
-	for peer, oldKey := range n.AppliedSystem.Peers {
-		newKey, ok := desired[peer]
-		if !ok || newKey != oldKey {
-			n.Log.Debug("removing", "peer", peer)
-			n.Device.RemovePeer(device.NoisePublicKey(oldKey))
-			delete(n.AppliedSystem.Peers, peer)
-		}
-	}
-
+	// Prepare every desired peer before removing any old peer. In particular,
+	// public-key rotation must keep the old peer alive until the forwarding
+	// table has been rebound to the replacement.
 	for _, peer := range slices.Sorted(slices.Values(n.GetPeers(n.LocalCfg.Id))) {
 		ncfg := n.GetNode(peer)
 		wgPeer := n.Device.LookupPeer(device.NoisePublicKey(ncfg.PubKey))
@@ -170,20 +169,31 @@ func (n *Nylon) SyncWireGuard() error {
 		if n.IsClient(peer) {
 			wgPeer.SetPreferRoaming(true)
 		}
-		n.AppliedSystem.Peers[peer] = ncfg.PubKey
 	}
 
-	return n.syncWireGuardEndpoints()
-}
-
-func (n *Nylon) UpdateWireGuard() error {
-	if n.Device == nil {
-		return nil
-	}
 	if err := n.syncWireGuardEndpoints(); err != nil {
 		return err
 	}
-	return n.SyncSystemState()
+
+	// The forwarding table caches concrete peers for the one-lookup hot path.
+	// Rebind every entry before stopping peers from the previous generation.
+	n.rebindForwardingPeers()
+
+	desiredKeys := make(map[state.NyPublicKey]struct{}, len(desired))
+	for _, key := range desired {
+		desiredKeys[key] = struct{}{}
+	}
+	for _, wgPeer := range n.Device.GetPeers() {
+		key := state.NyPublicKey(wgPeer.GetPublicKey())
+		if _, ok := desiredKeys[key]; ok {
+			continue
+		}
+		n.Log.Debug("removing obsolete WireGuard peer", "key", key)
+		n.Device.RemovePeer(wgPeer.GetPublicKey())
+	}
+
+	n.AppliedSystem.Peers = desired
+	return nil
 }
 
 func (n *Nylon) syncWireGuardEndpoints() error {
@@ -207,28 +217,11 @@ func (n *Nylon) syncWireGuardEndpoints() error {
 				return cmp.Compare(a.Metric(), b.Metric())
 			})
 			for _, ep := range links {
-				nep, err := ep.AsNylonEndpoint().GetWgEndpoint(n.Device)
+				nep, err := ep.AsNylonEndpoint().GetWgEndpoint(n.Device, n.EndpointResolver)
 				if err != nil {
 					continue
 				}
 				eps = append(eps, nep)
-			}
-		}
-
-		// add endpoint if it is not in the list
-		for _, ep := range pcfg.Endpoints {
-			ap, err := ep.Get()
-			if err != nil {
-				continue
-			}
-			if !slices.ContainsFunc(eps, func(endpoint conn.Endpoint) bool {
-				return endpoint.DstIPPort() == ap
-			}) {
-				endpoint, err := n.Device.Bind().ParseEndpoint(ap.String())
-				if err != nil {
-					return err
-				}
-				eps = append(eps, endpoint)
 			}
 		}
 
@@ -245,64 +238,83 @@ func (n *Nylon) SyncSystemState() error {
 	if n.NoNetConfigure {
 		return nil
 	}
-	if err := n.syncAliases(); err != nil {
-		return err
-	}
-	return n.syncSystemRoutes()
+	return errors.Join(n.syncAliases(), n.syncSystemRoutes())
 }
 
 func (n *Nylon) syncAliases() error {
 	desired := n.GetRouter(n.LocalCfg.Id).Addresses
+	applied := slices.Clone(n.AppliedSystem.Aliases)
+	var syncErr error
 	// we must first add the new alias before removing the old ones, else the system might flush our routes
 	for _, newEntry := range desired {
-		if !slices.Contains(n.AppliedSystem.Aliases, newEntry) {
+		if !slices.Contains(applied, newEntry) {
 			n.Log.Debug("installing alias", "addr", newEntry.String())
 			err := ConfigureAlias(n.Log, n.Interface, newEntry)
 			if err != nil {
 				n.Log.Error("failed to configure alias", "err", err)
+				syncErr = errors.Join(syncErr, fmt.Errorf("install alias %s: %w", newEntry, err))
+				continue
 			}
+			applied = append(applied, newEntry)
 		}
 	}
-	for _, oldEntry := range n.AppliedSystem.Aliases {
+	hadAliases := len(applied) != 0
+	for _, oldEntry := range slices.Clone(applied) {
 		if !slices.Contains(desired, oldEntry) {
 			n.Log.Debug("removing old alias", "addr", oldEntry.String())
 			err := RemoveAlias(n.Log, n.Interface, oldEntry)
 			if err != nil {
 				n.Log.Error("failed to remove alias", "err", err)
+				syncErr = errors.Join(syncErr, fmt.Errorf("remove alias %s: %w", oldEntry, err))
+				continue
 			}
+			applied = slices.DeleteFunc(applied, func(addr netip.Addr) bool {
+				return addr == oldEntry
+			})
 		}
 	}
 	// special case for linux: if all aliases are removed, the kernel will also flush the routes
-	if len(n.AppliedSystem.Aliases) != 0 && len(desired) == 0 && runtime.GOOS == "linux" {
+	if hadAliases && len(applied) == 0 && runtime.GOOS == "linux" {
 		n.AppliedSystem.Routes = nil
 	}
-	n.AppliedSystem.Aliases = slices.Clone(desired)
-	return nil
+	n.AppliedSystem.Aliases = applied
+	return syncErr
 }
 
 func (n *Nylon) syncSystemRoutes() error {
 	newEntries := n.ComputeSysRouteTable()
-	oldEntries := n.AppliedSystem.Routes
-	for _, oldEntry := range oldEntries {
+	applied := slices.Clone(n.AppliedSystem.Routes)
+	var syncErr error
+	// Install new routes before removing old ones so a partial reconciliation
+	// preserves as much connectivity as possible.
+	for _, newEntry := range newEntries {
+		if !slices.Contains(applied, newEntry) {
+			// install route
+			n.Log.Debug("installing new route", "prefix", newEntry.String())
+			err := ConfigureRoute(n.Log, n.Tun, n.Interface, newEntry)
+			if err != nil {
+				n.Log.Error("failed to configure route", "err", err)
+				syncErr = errors.Join(syncErr, fmt.Errorf("install route %s: %w", newEntry, err))
+				continue
+			}
+			applied = append(applied, newEntry)
+		}
+	}
+	for _, oldEntry := range slices.Clone(applied) {
 		if !slices.Contains(newEntries, oldEntry) {
 			// uninstall route
 			n.Log.Debug("removing old route", "prefix", oldEntry.String())
 			err := RemoveRoute(n.Log, n.Tun, n.Interface, oldEntry)
 			if err != nil {
 				n.Log.Error("failed to remove route", "err", err)
+				syncErr = errors.Join(syncErr, fmt.Errorf("remove route %s: %w", oldEntry, err))
+				continue
 			}
+			applied = slices.DeleteFunc(applied, func(prefix netip.Prefix) bool {
+				return prefix == oldEntry
+			})
 		}
 	}
-	for _, newEntry := range newEntries {
-		if !slices.Contains(oldEntries, newEntry) {
-			// install route
-			n.Log.Debug("installing new route", "prefix", newEntry.String())
-			err := ConfigureRoute(n.Log, n.Tun, n.Interface, newEntry)
-			if err != nil {
-				n.Log.Error("failed to configure route", "err", err)
-			}
-		}
-	}
-	n.AppliedSystem.Routes = slices.Clone(newEntries)
-	return nil
+	n.AppliedSystem.Routes = applied
+	return syncErr
 }

--- a/core/router.go
+++ b/core/router.go
@@ -21,6 +21,13 @@ type RouteTableEntry struct {
 	Blackhole bool
 }
 
+type ForwardingTables struct {
+	// Forward contains the full routing table.
+	Forward *bart.Table[RouteTableEntry]
+	// Exit contains only routes to services hosted on this node.
+	Exit *bart.Table[RouteTableEntry]
+}
+
 func (n *Nylon) GetNeighIO(neigh state.NodeId) *IOPending {
 	nio, ok := n.router.IO[neigh]
 	if !ok {
@@ -99,16 +106,16 @@ func (n *Nylon) UpdateNeighbour(neigh state.NodeId) {
 
 func (n *Nylon) TableInsertRoute(prefix netip.Prefix, route state.SelRoute) {
 	nh := route.Nh
-	nf := n.router.ForwardTable.Load().Clone()
-	ne := n.router.ExitTable.Load().Clone()
+	tables := n.router.Tables.Load()
+	nf := tables.Forward.Clone()
+	ne := tables.Exit.Clone()
 	if route.Metric == state.INF {
 		nf.Insert(prefix, RouteTableEntry{
 			Nh:        nh,
 			Blackhole: true,
 		})
 		ne.Delete(prefix)
-		n.router.ForwardTable.Store(nf)
-		n.router.ExitTable.Store(ne)
+		n.router.Tables.Store(&ForwardingTables{Forward: nf, Exit: ne})
 		return
 	}
 	peer := n.Device.LookupPeer(device.NoisePublicKey(n.GetNode(nh).PubKey))
@@ -124,17 +131,59 @@ func (n *Nylon) TableInsertRoute(prefix netip.Prefix, route state.SelRoute) {
 	} else {
 		ne.Delete(prefix)
 	}
-	n.router.ForwardTable.Store(nf)
-	n.router.ExitTable.Store(ne)
+	n.router.Tables.Store(&ForwardingTables{Forward: nf, Exit: ne})
 }
 
 func (n *Nylon) TableDeleteRoute(prefix netip.Prefix) {
-	nf := n.router.ForwardTable.Load().Clone()
-	ne := n.router.ExitTable.Load().Clone()
+	tables := n.router.Tables.Load()
+	nf := tables.Forward.Clone()
+	ne := tables.Exit.Clone()
 	nf.Delete(prefix)
 	ne.Delete(prefix)
-	n.router.ForwardTable.Store(nf)
-	n.router.ExitTable.Store(ne)
+	n.router.Tables.Store(&ForwardingTables{Forward: nf, Exit: ne})
+}
+
+func (n *Nylon) rebindForwardingPeers() {
+	if n.Device == nil {
+		return
+	}
+
+	tables := n.router.Tables.Load()
+	if tables == nil {
+		return
+	}
+
+	peers := make(map[state.NodeId]*device.Peer)
+	for _, node := range n.CentralCfg.GetNodes() {
+		peers[node.Id] = n.Device.LookupPeer(device.NoisePublicKey(node.PubKey))
+	}
+
+	forward, forwardChanged := rebindRouteTablePeers(tables.Forward, peers)
+	exit, exitChanged := rebindRouteTablePeers(tables.Exit, peers)
+	if forwardChanged || exitChanged {
+		n.router.Tables.Store(&ForwardingTables{Forward: forward, Exit: exit})
+	}
+}
+
+func rebindRouteTablePeers(table *bart.Table[RouteTableEntry], peers map[state.NodeId]*device.Peer) (*bart.Table[RouteTableEntry], bool) {
+	next := table
+	changed := false
+	for prefix, entry := range table.All() {
+		if entry.Blackhole {
+			continue
+		}
+		peer := peers[entry.Nh]
+		if entry.Peer == peer {
+			continue
+		}
+		if !changed {
+			next = table.Clone()
+			changed = true
+		}
+		entry.Peer = peer
+		next.Insert(prefix, entry)
+	}
+	return next, changed
 }
 
 type IOPending struct {
@@ -169,8 +218,10 @@ func (n *Nylon) InitRouter() error {
 	n.router.log = n.Log.With("module", log.ScopeRouter)
 	n.router.log.Debug("init router")
 	n.router.IO = make(map[state.NodeId]*IOPending)
-	n.router.ForwardTable.Store(new(bart.Table[RouteTableEntry]{}))
-	n.router.ExitTable.Store(new(bart.Table[RouteTableEntry]{}))
+	n.router.Tables.Store(&ForwardingTables{
+		Forward: new(bart.Table[RouteTableEntry]),
+		Exit:    new(bart.Table[RouteTableEntry]),
+	})
 	n.RouterState = &state.RouterState{
 		RouterTunables: &n.RouterTunables,
 		Id:             n.LocalCfg.Id,
@@ -180,16 +231,6 @@ func (n *Nylon) InitRouter() error {
 		Neighbours:     make([]*state.Neighbour, 0),
 		Advertised:     make(map[netip.Prefix]state.Advertisement),
 	}
-	maxTime := time.Unix(1<<63-62135596801, 999999999)
-	for _, prefix := range n.GetRouter(n.LocalCfg.Id).Prefixes {
-		n.RouterState.Advertised[prefix.GetPrefix()] = state.Advertisement{
-			NodeId:        n.LocalCfg.Id,
-			Expiry:        maxTime,
-			IsPassiveHold: false,
-			MetricFn:      prefix.GetMetric,
-		}
-	}
-
 	n.router.log.Debug("schedule router tasks")
 
 	n.RepeatTask(func() error {
@@ -248,12 +289,17 @@ func (n *Nylon) updatePassiveClient(prefix state.PrefixHealthWrapper, node state
 		n.RouterState.SetSeqno(prefix.GetPrefix(), n.RouterState.GetSeqno(prefix.GetPrefix())+1)
 	}
 
-	// passive nodes may only have static prefixes, so we don't call prefix.Start()
+	metric, ok := prefix.StaticMetric()
+	if !ok {
+		return
+	}
 	n.RouterState.Advertised[prefix.GetPrefix()] = state.Advertisement{
 		NodeId:        node,
 		Expiry:        time.Now().Add(n.ClientKeepaliveInterval),
 		IsPassiveHold: passiveHold,
-		MetricFn:      prefix.GetMetric,
+		MetricFn: func() uint32 {
+			return metric
+		},
 		ExpiryFn: func() {
 			// we didn't start the prefix monitoring
 		},

--- a/e2e/harness.go
+++ b/e2e/harness.go
@@ -537,8 +537,8 @@ func SimpleRouter(id string, pubKey state.NyPublicKey, nylonIP string, endpointI
 		},
 	}
 	if endpointIP != "" {
-		cfg.Endpoints = []*state.DynamicEndpoint{
-			state.NewDynamicEndpoint(fmt.Sprintf("%s:57175", endpointIP)),
+		cfg.Endpoints = []string{
+			fmt.Sprintf("%s:57175", endpointIP),
 		}
 	}
 	return cfg

--- a/e2e/healthcheck_test.go
+++ b/e2e/healthcheck_test.go
@@ -138,6 +138,7 @@ func TestHealthcheckHTTP(t *testing.T) {
 	clientIP := GetIP(h.Subnet, 20)
 	primaryIP := GetIP(h.Subnet, 21)
 	backupIP := GetIP(h.Subnet, 22)
+	dnsIP := GetIP(h.Subnet, 100)
 
 	// Keys
 	clientKey := state.GenerateKey()
@@ -150,6 +151,18 @@ func TestHealthcheckHTTP(t *testing.T) {
 	serviceIP := "10.0.3.1"
 	servicePrefixStr := serviceIP + "/32"
 	servicePrefix := netip.MustParsePrefix(servicePrefixStr)
+	healthHost := "health.service.test"
+	corefile := `
+. {
+    file /etc/coredns/service.test.db service.test
+    errors
+}
+`
+	zoneFile := fmt.Sprintf(`
+service.test. 0 IN SOA sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 0
+health.service.test. 0 IN A %s
+`, serviceIP)
+	h.StartDNS("dns", dnsIP, corefile, map[string]string{"service.test.db": zoneFile})
 
 	// 1. Central Config
 	central := state.CentralCfg{
@@ -170,7 +183,7 @@ func TestHealthcheckHTTP(t *testing.T) {
 		{
 			&state.HTTPPrefixHealth{
 				Prefix: servicePrefix,
-				URL:    fmt.Sprintf("http://%s:8080/health", serviceIP),
+				URL:    fmt.Sprintf("http://%s:8080/health", healthHost),
 				Delay:  new(1 * time.Second),
 				Metric: new(uint32(10)),
 			},
@@ -195,6 +208,7 @@ func TestHealthcheckHTTP(t *testing.T) {
 
 	primaryCfg := SimpleLocal("primary", primaryKey)
 	primaryCfg.PreUp = append(primaryCfg.PreUp, fmt.Sprintf("ip addr add %s dev lo", servicePrefixStr))
+	primaryCfg.DnsResolvers = []string{dnsIP + ":53"}
 
 	backupCfg := SimpleLocal("backup", backupKey)
 	backupCfg.PreUp = append(backupCfg.PreUp, fmt.Sprintf("ip addr add %s dev lo", servicePrefixStr))

--- a/e2e/passive_roaming_test.go
+++ b/e2e/passive_roaming_test.go
@@ -47,7 +47,7 @@ func TestPassiveRoaming(t *testing.T) {
 					PubKey:    pubKeys["node-1"],
 					Addresses: []netip.Addr{netip.MustParseAddr("10.0.0.1")},
 				},
-				Endpoints: []*state.DynamicEndpoint{state.NewDynamicEndpoint(fmt.Sprintf("%s:51820", ip1))},
+				Endpoints: []string{fmt.Sprintf("%s:51820", ip1)},
 			},
 			{
 				NodeCfg: state.NodeCfg{
@@ -55,7 +55,7 @@ func TestPassiveRoaming(t *testing.T) {
 					PubKey:    pubKeys["node-2"],
 					Addresses: []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 				},
-				Endpoints: []*state.DynamicEndpoint{state.NewDynamicEndpoint(fmt.Sprintf("%s:51820", ip2))},
+				Endpoints: []string{fmt.Sprintf("%s:51820", ip2)},
 			},
 			{
 				NodeCfg: state.NodeCfg{
@@ -63,7 +63,7 @@ func TestPassiveRoaming(t *testing.T) {
 					PubKey:    pubKeys["node-3"],
 					Addresses: []netip.Addr{netip.MustParseAddr("10.0.0.3")},
 				},
-				Endpoints: []*state.DynamicEndpoint{state.NewDynamicEndpoint(fmt.Sprintf("%s:51820", ip3))},
+				Endpoints: []string{fmt.Sprintf("%s:51820", ip3)},
 			},
 		},
 		Clients: []state.ClientCfg{

--- a/e2e/probe_test.go
+++ b/e2e/probe_test.go
@@ -149,7 +149,7 @@ func probeRouter(id string, pubKey state.NyPublicKey, nylonIP string, endpoint s
 		},
 	}
 	if endpoint != "" {
-		cfg.Endpoints = []*state.DynamicEndpoint{state.NewDynamicEndpoint(endpoint)}
+		cfg.Endpoints = []string{endpoint}
 	}
 	return cfg
 }

--- a/e2e/resolution_test.go
+++ b/e2e/resolution_test.go
@@ -52,8 +52,8 @@ _nylon._udp.srv.example.com. 0 IN SRV 10 10 57175 node2.example.com.
 					Addresses: []netip.Addr{netip.MustParseAddr("10.0.0.1")},
 				},
 				// Node 1's endpoint is a hostname
-				Endpoints: []*state.DynamicEndpoint{
-					state.NewDynamicEndpoint("example.com"),
+				Endpoints: []string{
+					"example.com",
 				},
 			},
 			{
@@ -63,8 +63,8 @@ _nylon._udp.srv.example.com. 0 IN SRV 10 10 57175 node2.example.com.
 					Addresses: []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 				},
 				// Node 2's endpoint is an SRV record
-				Endpoints: []*state.DynamicEndpoint{
-					state.NewDynamicEndpoint("srv.example.com"),
+				Endpoints: []string{
+					"srv.example.com",
 				},
 			},
 		},
@@ -164,8 +164,8 @@ node2.example.com. 0 IN A %s
 					Addresses: []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 				},
 				// Node 2's endpoint is a hostname
-				Endpoints: []*state.DynamicEndpoint{
-					state.NewDynamicEndpoint("node2.example.com"),
+				Endpoints: []string{
+					"node2.example.com",
 				},
 			},
 		},

--- a/integration/apply_config_test.go
+++ b/integration/apply_config_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"fmt"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -149,6 +150,95 @@ func TestApplyCentralConfigLocalNodeRemovedRequiresRestart(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, centralUnchanged)
 	assert.True(t, bStillNeighbour)
+}
+
+func TestApplyCentralConfigRotatesPeerKeyWithoutChangingNextHop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	vh := &VirtualHarness{UntrackedRouting: true}
+	a1 := "192.168.30.1:1234"
+	vh.NewNode("a", "10.0.0.1/32")
+	b1 := "192.168.30.2:1234"
+	vh.NewNode("b", "10.0.0.2/32")
+	vh.Central.Graph = []string{"a, b"}
+	vh.Endpoints = map[string]state.NodeId{
+		a1: "a",
+		b1: "b",
+	}
+	vh.AddLink(a1, b1)
+	vh.AddLink(b1, a1)
+
+	errs := vh.Start()
+	defer vh.Stop()
+
+	received := make(chan byte, 16)
+	vh.Net.SelfHandler = func(node state.NodeId, _, dst netip.Addr, data []byte) bool {
+		if node == "b" && dst == netip.MustParseAddr("10.0.0.2") && len(data) != 0 {
+			select {
+			case received <- data[0]:
+			default:
+			}
+		}
+		return true
+	}
+
+	waitForPayload(t, vh, errs, received, 1)
+
+	newPrivateKey := state.GenerateKey()
+	b := vh.Nylons[vh.IndexOf("b")].Load()
+	assert.NoError(t, b.Device.SetPrivateKey(device.NoisePrivateKey(newPrivateKey)))
+
+	err, next := vh.Central.Clone()
+	assert.NoError(t, err)
+	next.Timestamp++
+	next.Routers[vh.IndexOf("b")].PubKey = newPrivateKey.Pubkey()
+
+	applyConfigAndWait(t, b, next)
+	a := vh.Nylons[vh.IndexOf("a")].Load()
+	applyConfigAndWait(t, a, next)
+
+	waitForPayload(t, vh, errs, received, 2)
+}
+
+func applyConfigAndWait(t *testing.T, n *core.Nylon, cfg *state.CentralCfg) {
+	t.Helper()
+	done := make(chan struct{})
+	var result core.ApplyResult
+	var err error
+	n.Dispatch(func() error {
+		result, err = n.ApplyCentralConfig(cfg)
+		close(done)
+		return nil
+	})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for central config apply")
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, core.ApplyApplied, result)
+}
+
+func waitForPayload(t *testing.T, vh *VirtualHarness, errs <-chan error, received <-chan byte, payload byte) {
+	t.Helper()
+	timeout := time.NewTimer(10 * time.Second)
+	defer timeout.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case got := <-received:
+			if got == payload {
+				return
+			}
+		case <-ticker.C:
+			vh.Net.Send("a", "10.0.0.1", "10.0.0.2", []byte{payload}, 64)
+		case err := <-errs:
+			t.Fatal(err)
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for payload %d", payload)
+		}
+	}
 }
 
 type applyResult struct {

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -185,7 +185,7 @@ func (v *VirtualHarness) Start() chan error {
 	}
 	for e, n := range v.Endpoints {
 		idx := v.IndexOf(n)
-		v.Central.Routers[idx].Endpoints = append(v.Central.Routers[idx].Endpoints, state.NewDynamicEndpoint(e))
+		v.Central.Routers[idx].Endpoints = append(v.Central.Routers[idx].Endpoints, e)
 	}
 	if v.LogLevel == nil {
 		v.LogLevel = new(slog.LevelDebug)

--- a/integration/ipc_test.go
+++ b/integration/ipc_test.go
@@ -159,7 +159,7 @@ func TestIPCReloadConfig(t *testing.T) {
 	case resp := <-done:
 		assert.True(t, resp.Ok)
 		r := resp.GetReload()
-		assert.Contains(t, []protocol.ReloadResult{protocol.ReloadResult_APPLIED}, r.Result)
+		assert.Equal(t, protocol.ReloadResult_NOOP, r.Result)
 	case err := <-errs:
 		t.Fatal(err)
 	case <-time.After(10 * time.Second):

--- a/integration/race_test.go
+++ b/integration/race_test.go
@@ -59,18 +59,6 @@ func TestRapidToggleConfig(t *testing.T) {
 
 	a := vh.Nylons[vh.IndexOf("a")].Load()
 
-	// Break shared *DynamicEndpoint pointers from startup.
-	{
-		done := make(chan struct{})
-		a.Dispatch(func() error {
-			_, nc := a.CentralCfg.Clone()
-			a.CentralCfg = *nc
-			close(done)
-			return nil
-		})
-		<-done
-	}
-
 	// Send packets every 10ms to trigger ForwardTable.Lookup via TC filter.
 	stop := make(chan struct{})
 	go func() {

--- a/state/config.go
+++ b/state/config.go
@@ -21,7 +21,7 @@ type NodeCfg struct {
 // RouterCfg represents a central representation of a node that can route
 type RouterCfg struct {
 	NodeCfg   `yaml:",inline"`
-	Endpoints []*DynamicEndpoint
+	Endpoints []string
 }
 type ClientCfg struct {
 	NodeCfg `yaml:",inline"`
@@ -55,7 +55,7 @@ type LocalCfg struct {
 	Dist             *LocalDistributionCfg `yaml:",omitempty"`                   // distribution configuration
 	UseSystemRouting bool                  `yaml:"use_system_routing,omitempty"` // all packets from peers will come out of the TUN interface
 	NoNetConfigure   bool                  `yaml:"no_net_configure,omitempty"`   // do not configure system networking at all
-	DnsResolvers     []string              `yaml:"dns_resolvers,omitempty"`      // dns resolvers used by nylon, currently only for config repo
+	DnsResolvers     []string              `yaml:"dns_resolvers,omitempty"`      // DNS resolvers used for endpoints and config repositories
 	InterfaceName    string                `yaml:"interface_name,omitempty"`     // the name of the nylon interface
 	LogPath          string                `yaml:"log_path,omitempty"`           // if not empty, nylon will write to this file
 	UnexcludeIPs     []netip.Prefix        `yaml:"unexclude_ips,omitempty"`      // split tunnel, subtracts from centrally excluded ip ranges
@@ -376,24 +376,31 @@ func (e *CentralCfg) FindNodeBy(pkey NyPublicKey) *NodeId {
 func ExpandCentralConfig(cfg *CentralCfg) {
 	// compatibility & convenience: advertise address as a host address (/32 or /128)
 	for idx, node := range cfg.Routers {
-		for _, addr := range node.Addresses {
-			advAddress := StaticPrefixHealth{
-				Prefix: AddrToPrefix(addr),
-				Metric: 0,
-			}
-			node.Prefixes = append([]PrefixHealthWrapper{{&advAddress}}, node.Prefixes...)
-		}
+		expandNodeAddresses(&node.NodeCfg)
 		cfg.Routers[idx] = node
 	}
 	for idx, node := range cfg.Clients {
-		for _, addr := range node.Addresses {
-			advAddress := StaticPrefixHealth{
-				Prefix: AddrToPrefix(addr),
-				Metric: 0,
-			}
-			node.Prefixes = append([]PrefixHealthWrapper{{&advAddress}}, node.Prefixes...)
-		}
+		expandNodeAddresses(&node.NodeCfg)
 		cfg.Clients[idx] = node
+	}
+}
+
+func expandNodeAddresses(node *NodeCfg) {
+	prefixes := make(map[netip.Prefix]struct{}, len(node.Prefixes))
+	for _, prefix := range node.Prefixes {
+		prefixes[prefix.GetPrefix()] = struct{}{}
+	}
+	for _, addr := range node.Addresses {
+		prefix := AddrToPrefix(addr)
+		if _, ok := prefixes[prefix]; ok {
+			continue
+		}
+		advAddress := StaticPrefixHealth{
+			Prefix: prefix,
+			Metric: 0,
+		}
+		node.Prefixes = append([]PrefixHealthWrapper{{&advAddress}}, node.Prefixes...)
+		prefixes[prefix] = struct{}{}
 	}
 }
 

--- a/state/config_test.go
+++ b/state/config_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -148,4 +149,23 @@ func TestParseGraph_InvalidGraph(t *testing.T) {
 	failGraph(t, `1,2,3,4,5,6,7,8,9,10,11,12,13,14,15`)
 	failGraph(t, `,,,,,,,,,,,,,,,,`)
 	failGraph(t, `a=a`)
+}
+
+func TestExpandCentralConfigIsIdempotent(t *testing.T) {
+	addr := netip.MustParseAddr("192.0.2.1")
+	cfg := CentralCfg{
+		Routers: []RouterCfg{{
+			NodeCfg: NodeCfg{
+				Id:        "router",
+				Addresses: []netip.Addr{addr},
+			},
+		}},
+	}
+
+	ExpandCentralConfig(&cfg)
+	ExpandCentralConfig(&cfg)
+
+	if assert.Len(t, cfg.Routers[0].Prefixes, 1) {
+		assert.Equal(t, AddrToPrefix(addr), cfg.Routers[0].Prefixes[0].GetPrefix())
+	}
 }

--- a/state/dns.go
+++ b/state/dns.go
@@ -2,22 +2,36 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 	"time"
 )
 
-// SetResolvers configures the global default resolver
-func SetResolvers(resolvers []string) {
-	if len(resolvers) != 0 {
-		net.DefaultResolver = &net.Resolver{
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				d := net.Dialer{Timeout: time.Second * 10}
+// DNSResolver performs Nylon's DNS lookups without changing net.DefaultResolver.
+// A Nylon instance can therefore use its configured DNS servers independently
+// from other instances in the same process.
+type DNSResolver struct {
+	resolver *net.Resolver
+}
+
+func NewDNSResolver(servers []string) *DNSResolver {
+	if len(servers) == 0 {
+		return &DNSResolver{resolver: net.DefaultResolver}
+	}
+
+	servers = slices.Clone(servers)
+	return &DNSResolver{
+		resolver: &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				dialer := net.Dialer{Timeout: 10 * time.Second}
 				var lastErr error
-				for _, r := range resolvers {
-					conn, err := d.DialContext(ctx, network, r)
+				for _, server := range servers {
+					conn, err := dialer.DialContext(ctx, network, server)
 					if err == nil {
 						return conn, nil
 					}
@@ -25,34 +39,58 @@ func SetResolvers(resolvers []string) {
 				}
 				return nil, lastErr
 			},
-		}
+		},
 	}
 }
 
-// ResolveName resolves a hostname to a list of IP addresses
-func ResolveName(ctx context.Context, host string) ([]netip.Addr, error) {
-	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+func (r *DNSResolver) ResolveName(ctx context.Context, host string) ([]netip.Addr, error) {
+	ips, err := r.resolver.LookupHost(ctx, host)
 	if err != nil {
 		return nil, err
 	}
-	var addrs []netip.Addr
-	for _, ipStr := range ips {
-		if addr, err := netip.ParseAddr(ipStr); err == nil {
+	addrs := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		if addr, err := netip.ParseAddr(ip); err == nil {
 			addrs = append(addrs, addr)
 		}
 	}
 	return addrs, nil
 }
 
-// ResolveSRV resolves an SRV record using the default resolver
-func ResolveSRV(ctx context.Context, service, proto, name string) (string, uint16, error) {
-	_, addrs, err := net.DefaultResolver.LookupSRV(ctx, service, proto, name)
+func (r *DNSResolver) ResolveSRV(ctx context.Context, service, proto, name string) (string, uint16, error) {
+	_, records, err := r.resolver.LookupSRV(ctx, service, proto, name)
 	if err != nil {
 		return "", 0, err
 	}
-	if len(addrs) == 0 {
+	if len(records) == 0 {
 		return "", 0, fmt.Errorf("no SRV records found")
 	}
-	// Return the first SRV target and port
-	return strings.TrimSuffix(addrs[0].Target, "."), addrs[0].Port, nil
+	return strings.TrimSuffix(records[0].Target, "."), records[0].Port, nil
+}
+
+// DialContext resolves address through this Nylon instance's configured DNS
+// servers before dialing it.
+func (r *DNSResolver) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := r.ResolveName(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no addresses found for %s", host)
+	}
+
+	var dialErr error
+	var dialer net.Dialer
+	for _, addr := range addrs {
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(addr.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		dialErr = errors.Join(dialErr, err)
+	}
+	return nil, fmt.Errorf("failed to dial %s: %w", address, dialErr)
 }

--- a/state/endpoint.go
+++ b/state/endpoint.go
@@ -1,13 +1,9 @@
 package state
 
 import (
-	"context"
 	"fmt"
 	"math"
-	"net"
-	"net/netip"
 	"slices"
-	"strconv"
 	"sync"
 	"time"
 
@@ -23,135 +19,6 @@ type Endpoint interface {
 	AsNylonEndpoint() *NylonEndpoint
 }
 
-/*
-		DynamicEndpoint represents either an ip:port or a dns name. This may be resolved to a different address at any time
-
-		Examples:
-	    - nylon.example.com -> resolves to <ip>:57175 (DefaultPort)
-		- nylon2.example.com:12345 -> resolves to <ip>:12345
-		- SRV record: _nylon._udp.example.com. port: 8000 target: nylon3.example.com -> resolves to <ip>:8000
-*/
-type DynamicEndpoint struct {
-	Value      string
-	lastValue  netip.AddrPort
-	lastUpdate time.Time
-	rw         *sync.RWMutex
-}
-
-func NewDynamicEndpoint(value string) *DynamicEndpoint {
-	return &DynamicEndpoint{
-		Value: value,
-		rw:    &sync.RWMutex{},
-	}
-}
-
-func (ep *DynamicEndpoint) Parse() (host string, port uint16, err error) {
-	// Try to parse as AddrPort directly first to handle cases like [::1]:port correctly
-	if ap, err := netip.ParseAddrPort(ep.Value); err == nil {
-		return ap.Addr().String(), ap.Port(), nil
-	}
-
-	h, portStr, err := net.SplitHostPort(ep.Value)
-	if err != nil {
-		// No port specified?
-		// TODO: more robust validation
-		return ep.Value, uint16(DefaultPort), nil
-	} else {
-		p, err := strconv.ParseUint(portStr, 10, 16)
-		if err != nil {
-			return "", 0, fmt.Errorf("invalid port: %w", err)
-		}
-		return h, uint16(p), nil
-	}
-}
-
-func (ep *DynamicEndpoint) Refresh(resolveExpiry time.Duration) (netip.AddrPort, error) {
-	// 1. Try to parse as AddrPort directly
-	if ap, err := netip.ParseAddrPort(ep.Value); err == nil {
-		return ap, nil
-	}
-
-	ep.rw.RLock()
-	// if this endpoint is down, we will refresh every EndpointResolveDelay
-	if time.Since(ep.lastUpdate) < resolveExpiry && ep.lastValue != (netip.AddrPort{}) {
-		ep.rw.RUnlock()
-		return ep.lastValue, nil
-	}
-	ep.rw.RUnlock()
-
-	host, port, err := ep.Parse()
-	if err != nil {
-		return netip.AddrPort{}, err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
-	// 2. Try SRV lookup
-	target, srvPort, err := ResolveSRV(ctx, "nylon", "udp", host)
-	if err == nil {
-		addrs, err := ResolveName(ctx, target)
-		if err == nil && len(addrs) > 0 {
-			ep.rw.Lock()
-			defer ep.rw.Unlock()
-			ep.lastUpdate = time.Now()
-			ep.lastValue = netip.AddrPortFrom(addrs[0], srvPort)
-			return ep.lastValue, nil
-		}
-	}
-
-	// 3. Normal A/AAAA lookup
-	addrs, err := ResolveName(ctx, host)
-	if err != nil {
-		return netip.AddrPort{}, err
-	}
-	if len(addrs) == 0 {
-		return netip.AddrPort{}, fmt.Errorf("no addresses found for %s", host)
-	}
-
-	ep.rw.Lock()
-	defer ep.rw.Unlock()
-	ep.lastUpdate = time.Now()
-	ep.lastValue = netip.AddrPortFrom(addrs[0], port)
-	return ep.lastValue, nil
-}
-
-func (ep *DynamicEndpoint) Get() (netip.AddrPort, error) {
-	if ap, err := netip.ParseAddrPort(ep.Value); err == nil {
-		return ap, nil
-	}
-	ep.rw.RLock()
-	defer ep.rw.RUnlock()
-	if ep.lastValue != (netip.AddrPort{}) {
-		return ep.lastValue, nil
-	}
-	return netip.AddrPort{}, fmt.Errorf("endpoint not resolved")
-}
-
-func (ep *DynamicEndpoint) Clear() {
-	ep.rw.Lock()
-	defer ep.rw.Unlock()
-	ep.lastUpdate = time.Time{}
-}
-
-func (ep *DynamicEndpoint) String() string {
-	return ep.Value
-}
-
-func (ep *DynamicEndpoint) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return err
-	}
-	ep.Value = s
-	ep.rw = &sync.RWMutex{}
-	return nil
-}
-
-func (ep *DynamicEndpoint) MarshalYAML() (interface{}, error) {
-	return ep.Value, nil
-}
-
 type NylonEndpoint struct {
 	sync.RWMutex  // this mutex is for rtt smoothing and metric calculation
 	t             *RouterTunables
@@ -163,15 +30,15 @@ type NylonEndpoint struct {
 	expRTT        float64
 	remoteInit    bool
 	WgEndpoint    conn.Endpoint
-	DynEP         *DynamicEndpoint
+	Address       string
 }
 
 func (ep *NylonEndpoint) AsNylonEndpoint() *NylonEndpoint {
 	return ep
 }
 
-func (ep *NylonEndpoint) GetWgEndpoint(device *device.Device) (conn.Endpoint, error) {
-	ap, err := ep.DynEP.Get()
+func (ep *NylonEndpoint) GetWgEndpoint(device *device.Device, resolver *EndpointResolver) (conn.Endpoint, error) {
+	ap, err := resolver.Get(ep.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -225,12 +92,12 @@ func (u *NylonEndpoint) IsAlive() bool {
 	return u.IsActive() || !u.remoteInit // we never gc endpoints that we have in our config
 }
 
-func NewEndpoint(endpoint *DynamicEndpoint, remoteInit bool, wgEndpoint conn.Endpoint, t *RouterTunables) *NylonEndpoint {
+func NewEndpoint(address string, remoteInit bool, wgEndpoint conn.Endpoint, t *RouterTunables) *NylonEndpoint {
 	return &NylonEndpoint{
 		t:          t,
 		remoteInit: remoteInit,
 		WgEndpoint: wgEndpoint,
-		DynEP:      endpoint,
+		Address:    address,
 		history:    make([]time.Duration, 0),
 		expRTT:     math.Inf(1),
 	}

--- a/state/endpoint_resolver.go
+++ b/state/endpoint_resolver.go
@@ -1,0 +1,198 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type dnsLookup interface {
+	ResolveName(ctx context.Context, host string) ([]netip.Addr, error)
+	ResolveSRV(ctx context.Context, service, proto, name string) (string, uint16, error)
+}
+
+// EndpointResolver centrally owns resolved endpoint state for a Nylon instance.
+// Cache entries are shared by every link configured with the same address.
+type EndpointResolver struct {
+	dns   dnsLookup
+	mu    sync.RWMutex
+	cache map[string]*endpointResolution
+}
+
+type endpointResolution struct {
+	mu      sync.RWMutex
+	refresh sync.Mutex
+	value   netip.AddrPort
+	updated time.Time
+}
+
+func NewEndpointResolver(dns *DNSResolver) *EndpointResolver {
+	if dns == nil {
+		dns = NewDNSResolver(nil)
+	}
+	return newEndpointResolver(dns)
+}
+
+func newEndpointResolver(dns dnsLookup) *EndpointResolver {
+	return &EndpointResolver{
+		dns:   dns,
+		cache: make(map[string]*endpointResolution),
+	}
+}
+
+func (r *EndpointResolver) Resolve(endpoint string, expiry time.Duration) (netip.AddrPort, error) {
+	if addr, err := netip.ParseAddrPort(endpoint); err == nil {
+		return addr, nil
+	}
+
+	entry := r.entry(endpoint)
+	entry.mu.RLock()
+	value, updated := entry.value, entry.updated
+	entry.mu.RUnlock()
+	if value.IsValid() && time.Since(updated) < expiry {
+		return value, nil
+	}
+
+	host, port, err := parseEndpoint(endpoint)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+
+	// Only one goroutine refreshes an endpoint at a time, but do not hold the
+	// value lock while doing DNS I/O. Dispatch-path readers must be able to keep
+	// using the last successful resolution while a refresh is in flight.
+	entry.refresh.Lock()
+	defer entry.refresh.Unlock()
+	entry.mu.RLock()
+	value, updated = entry.value, entry.updated
+	entry.mu.RUnlock()
+	if value.IsValid() && time.Since(updated) < expiry {
+		return value, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if target, srvPort, err := r.dns.ResolveSRV(ctx, "nylon", "udp", host); err == nil {
+		if addrs, err := r.dns.ResolveName(ctx, target); err == nil && len(addrs) > 0 {
+			value = netip.AddrPortFrom(addrs[0], srvPort)
+			entry.mu.Lock()
+			entry.updated = time.Now()
+			entry.value = value
+			entry.mu.Unlock()
+			return value, nil
+		}
+	}
+
+	addrs, err := r.dns.ResolveName(ctx, host)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	if len(addrs) == 0 {
+		return netip.AddrPort{}, fmt.Errorf("no addresses found for %s", host)
+	}
+
+	value = netip.AddrPortFrom(addrs[0], port)
+	entry.mu.Lock()
+	entry.updated = time.Now()
+	entry.value = value
+	entry.mu.Unlock()
+	return value, nil
+}
+
+func (r *EndpointResolver) Get(endpoint string) (netip.AddrPort, error) {
+	if addr, err := netip.ParseAddrPort(endpoint); err == nil {
+		return addr, nil
+	}
+
+	r.mu.RLock()
+	entry := r.cache[endpoint]
+	r.mu.RUnlock()
+	if entry == nil {
+		return netip.AddrPort{}, fmt.Errorf("endpoint not resolved")
+	}
+
+	entry.mu.RLock()
+	defer entry.mu.RUnlock()
+	if entry.value.IsValid() {
+		return entry.value, nil
+	}
+	return netip.AddrPort{}, fmt.Errorf("endpoint not resolved")
+}
+
+// Expire makes the next Resolve refresh an endpoint while preserving the last
+// usable value until that refresh succeeds.
+func (r *EndpointResolver) Expire(endpoint string) {
+	r.mu.RLock()
+	entry := r.cache[endpoint]
+	r.mu.RUnlock()
+	if entry == nil {
+		return
+	}
+	entry.mu.Lock()
+	entry.updated = time.Time{}
+	entry.mu.Unlock()
+}
+
+// Retain removes cached resolutions for addresses no longer present in runtime
+// state. In-flight resolutions may finish using a removed entry, but it will no
+// longer be reachable from the central cache.
+func (r *EndpointResolver) Retain(addresses map[string]struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for address := range r.cache {
+		if _, ok := addresses[address]; !ok {
+			delete(r.cache, address)
+		}
+	}
+}
+
+func (r *EndpointResolver) entry(endpoint string) *endpointResolution {
+	r.mu.RLock()
+	entry := r.cache[endpoint]
+	r.mu.RUnlock()
+	if entry != nil {
+		return entry
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if entry = r.cache[endpoint]; entry == nil {
+		entry = new(endpointResolution)
+		r.cache[endpoint] = entry
+	}
+	return entry
+}
+
+func parseEndpoint(value string) (host string, port uint16, err error) {
+	if value == "" {
+		return "", 0, fmt.Errorf("endpoint is empty")
+	}
+	if strings.Contains(value, "://") {
+		return "", 0, fmt.Errorf("invalid endpoint %q", value)
+	}
+	if addr, err := netip.ParseAddrPort(value); err == nil {
+		return addr.Addr().String(), addr.Port(), nil
+	}
+	if addr, err := netip.ParseAddr(value); err == nil {
+		return addr.String(), uint16(DefaultPort), nil
+	}
+
+	host, portString, err := net.SplitHostPort(value)
+	if err != nil {
+		if strings.Contains(value, ":") {
+			return "", 0, fmt.Errorf("invalid endpoint %q: %w", value, err)
+		}
+		return value, uint16(DefaultPort), nil
+	}
+	portValue, err := strconv.ParseUint(portString, 10, 16)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid port: %w", err)
+	}
+	return host, uint16(portValue), nil
+}

--- a/state/endpoint_resolver_test.go
+++ b/state/endpoint_resolver_test.go
@@ -1,0 +1,168 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointResolverSharesResolutionByAddress(t *testing.T) {
+	dns := &countingDNSResolver{}
+	resolver := newEndpointResolver(dns)
+
+	const workers = 8
+	type resolveResult struct {
+		addr netip.AddrPort
+		err  error
+	}
+	results := make(chan resolveResult, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			addr, err := resolver.Resolve("router.example.com:1234", time.Hour)
+			results <- resolveResult{addr: addr, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	expected := netip.MustParseAddrPort("192.0.2.1:1234")
+	for result := range results {
+		require.NoError(t, result.err)
+		assert.Equal(t, expected, result.addr)
+	}
+	assert.Equal(t, 1, dns.NameCalls())
+
+	resolver.Expire("router.example.com:1234")
+	result, err := resolver.Resolve("router.example.com:1234", time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+	assert.Equal(t, 2, dns.NameCalls())
+}
+
+func TestEndpointResolverDoesNotCacheLiteralAddrPort(t *testing.T) {
+	dns := &countingDNSResolver{}
+	resolver := newEndpointResolver(dns)
+
+	expected := netip.MustParseAddrPort("[2001:db8::1]:57175")
+	result, err := resolver.Resolve(expected.String(), time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+
+	result, err = resolver.Get(expected.String())
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+	assert.Zero(t, dns.NameCalls())
+}
+
+func TestEndpointResolverPrunesUnusedAddresses(t *testing.T) {
+	resolver := newEndpointResolver(&countingDNSResolver{})
+	const address = "router.example.com:1234"
+
+	_, err := resolver.Resolve(address, time.Hour)
+	require.NoError(t, err)
+	resolver.Retain(map[string]struct{}{})
+
+	_, err = resolver.Get(address)
+	assert.ErrorContains(t, err, "not resolved")
+}
+
+func TestEndpointResolverGetDoesNotWaitForRefresh(t *testing.T) {
+	dns := &blockingDNSResolver{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	resolver := newEndpointResolver(dns)
+	const endpoint = "router.example.com:1234"
+
+	expected, err := resolver.Resolve(endpoint, time.Hour)
+	require.NoError(t, err)
+	resolver.Expire(endpoint)
+	dns.block = true
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(dns.release)
+		})
+	}
+	t.Cleanup(release)
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := resolver.Resolve(endpoint, time.Hour)
+		refreshDone <- err
+	}()
+	<-dns.started
+
+	type getResult struct {
+		addr netip.AddrPort
+		err  error
+	}
+	getDone := make(chan getResult, 1)
+	go func() {
+		addr, err := resolver.Get(endpoint)
+		getDone <- getResult{addr: addr, err: err}
+	}()
+
+	select {
+	case result := <-getDone:
+		require.NoError(t, result.err)
+		assert.Equal(t, expected, result.addr)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Get blocked behind an in-flight DNS refresh")
+	}
+
+	release()
+	require.NoError(t, <-refreshDone)
+}
+
+type countingDNSResolver struct {
+	mu        sync.Mutex
+	nameCalls int
+}
+
+func (r *countingDNSResolver) ResolveName(context.Context, string) ([]netip.Addr, error) {
+	r.mu.Lock()
+	r.nameCalls++
+	r.mu.Unlock()
+	return []netip.Addr{netip.MustParseAddr("192.0.2.1")}, nil
+}
+
+func (*countingDNSResolver) ResolveSRV(context.Context, string, string, string) (string, uint16, error) {
+	return "", 0, errors.New("no SRV record")
+}
+
+func (r *countingDNSResolver) NameCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.nameCalls
+}
+
+type blockingDNSResolver struct {
+	block   bool
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingDNSResolver) ResolveName(context.Context, string) ([]netip.Addr, error) {
+	if r.block {
+		r.once.Do(func() {
+			close(r.started)
+		})
+		<-r.release
+	}
+	return []netip.Addr{netip.MustParseAddr("192.0.2.1")}, nil
+}
+
+func (*blockingDNSResolver) ResolveSRV(context.Context, string, string, string) (string, uint16, error) {
+	return "", 0, errors.New("no SRV record")
+}

--- a/state/endpoint_test.go
+++ b/state/endpoint_test.go
@@ -53,7 +53,7 @@ type DataSource struct {
 func runTests(t *testing.T, ping func(i int) float64, dura time.Duration, fn string) (DataSource, DataSource) {
 	t.Helper()
 	tunables := DefaultRouterTunables()
-	dep := NewEndpoint(NewDynamicEndpoint("127.0.0.1:0"), false, nil, &tunables)
+	dep := NewEndpoint("127.0.0.1:0", false, nil, &tunables)
 
 	truth := DataSource{
 		Name: "Truth",
@@ -207,7 +207,7 @@ func TestEndpointNormal(t *testing.T) {
 	assert.Less(t, len(distinctValues), int(time.Hour*2/time.Minute))
 }
 
-func TestDynamicEndpoint_Parse(t *testing.T) {
+func TestParseEndpoint(t *testing.T) {
 	tests := []struct {
 		name         string
 		input        string
@@ -259,8 +259,7 @@ func TestDynamicEndpoint_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ep := NewDynamicEndpoint(tt.input)
-			host, port, err := ep.Parse()
+			host, port, err := parseEndpoint(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/state/prefix_health.go
+++ b/state/prefix_health.go
@@ -7,16 +7,23 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/digineo/go-ping"
 )
 
-type PrefixHealth interface {
-	GetMetric() uint32 // Metric does not block, and returns the advertised metric for this prefix
+// PrefixHealthConfig is immutable configuration stored in CentralCfg.
+// Runtime workers and their metrics are owned separately by PrefixHealthMonitor.
+type PrefixHealthConfig interface {
 	GetPrefix() netip.Prefix
-	Start(log *slog.Logger, t *RouterTunables) // Start begins any background monitoring required for this prefix
+	sameConfig(other PrefixHealthConfig, tunables *RouterTunables) bool
+	newMonitor(log *slog.Logger, tunables *RouterTunables, resolver *DNSResolver) PrefixHealthMonitor
+}
+
+type PrefixHealthMonitor interface {
+	GetMetric() uint32
 	Stop()
 }
 
@@ -26,24 +33,28 @@ type StaticPrefixHealth struct {
 	Metric uint32       `yaml:"metric,omitempty"` // the metric to advertise for this prefix
 }
 
-func (s *StaticPrefixHealth) Stop() {
-	// do nothing
-}
-
-func (s *StaticPrefixHealth) GetMetric() uint32 {
-	return s.Metric
-}
 func (s *StaticPrefixHealth) GetPrefix() netip.Prefix {
 	return s.Prefix
 }
-func (s *StaticPrefixHealth) Start(log *slog.Logger, t *RouterTunables) {
-	// do nothing
-}
 
-func (s *StaticPrefixHealth) sameConfig(other PrefixHealth, _ *RouterTunables) bool {
+func (s *StaticPrefixHealth) sameConfig(other PrefixHealthConfig, _ *RouterTunables) bool {
 	o, ok := other.(*StaticPrefixHealth)
 	return ok && s.Prefix == o.Prefix && s.Metric == o.Metric
 }
+
+func (s *StaticPrefixHealth) newMonitor(_ *slog.Logger, _ *RouterTunables, _ *DNSResolver) PrefixHealthMonitor {
+	return staticPrefixHealthMonitor{metric: s.Metric}
+}
+
+type staticPrefixHealthMonitor struct {
+	metric uint32
+}
+
+func (s staticPrefixHealthMonitor) GetMetric() uint32 {
+	return s.metric
+}
+
+func (staticPrefixHealthMonitor) Stop() {}
 
 type PingPrefixHealth struct {
 	Prefix      netip.Prefix   `yaml:"prefix"`
@@ -52,12 +63,6 @@ type PingPrefixHealth struct {
 	Delay       *time.Duration `yaml:"delay,omitempty"`        // delay between pings
 	BindIf      string         `yaml:"bind_if,omitempty"`      // local interface to bind to
 	Metric      *uint32        `yaml:"metric,omitempty"`       // metric override
-	lastMetric  atomic.Uint32
-	running     atomic.Bool
-}
-
-func (p *PingPrefixHealth) Stop() {
-	p.running.Swap(false)
 }
 
 func GetIfIP(itf string, is6 bool) (string, error) {
@@ -83,77 +88,11 @@ func GetIfIP(itf string, is6 bool) (string, error) {
 	return "", fmt.Errorf("no address found for interface %s", itf)
 }
 
-func (p *PingPrefixHealth) GetMetric() uint32 {
-	if p.Metric != nil {
-		return *p.Metric
-	}
-	return p.lastMetric.Load()
-}
 func (p *PingPrefixHealth) GetPrefix() netip.Prefix {
 	return p.Prefix
 }
-func (p *PingPrefixHealth) Start(log *slog.Logger, t *RouterTunables) {
-	if p.running.Swap(true) {
-		return
-	}
-	if p.Delay == nil {
-		p.Delay = &t.HealthCheckDelay
-	}
-	if p.MaxFailures == nil {
-		p.MaxFailures = &t.HealthCheckMaxFailures
-	}
-	// Default to unreachable until the first successful probe.
-	p.lastMetric.Store(INF)
-	go func() {
-		ticker := time.NewTicker(*p.Delay)
-		for p.running.Load() {
-			time.Sleep(*p.Delay)
-			bind4 := ""
-			bind6 := ""
-			var err error
-			if p.Addr.Is6() {
-				if p.BindIf != "" {
-					bind6, err = GetIfIP(p.BindIf, true)
-				} else {
-					bind6 = "::"
-				}
-			} else {
-				if p.BindIf != "" {
-					bind4, err = GetIfIP(p.BindIf, false)
-				} else {
-					bind4 = "0.0.0.0"
-				}
-			}
-			if err != nil {
-				log.Error("failed to get bind address", "error", err)
-				continue
-			}
-			pinger, err := ping.New(bind4, bind6)
-			if err != nil {
-				log.Error("failed to start pinger", "error", err)
-				continue
-			}
-			for p.running.Load() { // TODO: add a way to interrupt this sleep, if ticker has a high delay
-				<-ticker.C
-				// ICMP ping
-				addr := &net.IPAddr{IP: net.IP(p.Addr.AsSlice())}
-				rtt, err := pinger.PingAttempts(addr, time.Duration(int64(*p.Delay)/int64(*p.MaxFailures)), *p.MaxFailures)
-				if err != nil {
-					// failed
-					p.lastMetric.Store(INF)
-					log.Debug("prefix healthcheck failed", "prefix", p.Prefix.String(), "addr", p.Addr.String(), "error", err)
-					pinger.Close()
-					break // break to outer loop to recreate pinger
-				} else {
-					// success
-					p.lastMetric.Store(DurationToMetric(rtt))
-				}
-			}
-		}
-	}()
-}
 
-func (p *PingPrefixHealth) sameConfig(other PrefixHealth, tunables *RouterTunables) bool {
+func (p *PingPrefixHealth) sameConfig(other PrefixHealthConfig, tunables *RouterTunables) bool {
 	o, ok := other.(*PingPrefixHealth)
 	return ok &&
 		p.Prefix == o.Prefix &&
@@ -164,73 +103,136 @@ func (p *PingPrefixHealth) sameConfig(other PrefixHealth, tunables *RouterTunabl
 		prefixHealthMaxFailures(p.MaxFailures, tunables) == prefixHealthMaxFailures(o.MaxFailures, tunables)
 }
 
-type HTTPPrefixHealth struct {
-	Prefix     netip.Prefix   `yaml:"prefix"`
-	URL        string         `yaml:"url"`              // the URL to check
-	Delay      *time.Duration `yaml:"delay,omitempty"`  // delay between probes
-	Metric     *uint32        `yaml:"metric,omitempty"` // metric override
-	lastMetric atomic.Uint32
-	running    atomic.Bool
-}
-
-func (h *HTTPPrefixHealth) Stop() {
-	h.running.Swap(false)
-}
-
-func (h *HTTPPrefixHealth) GetMetric() uint32 {
-	if h.Metric != nil {
-		return *h.Metric
+func (p *PingPrefixHealth) newMonitor(log *slog.Logger, tunables *RouterTunables, _ *DNSResolver) PrefixHealthMonitor {
+	monitor := &pingPrefixHealthMonitor{
+		log:         log,
+		prefix:      p.Prefix,
+		addr:        p.Addr,
+		bindIf:      p.BindIf,
+		delay:       prefixHealthDelay(p.Delay, tunables),
+		maxFailures: prefixHealthMaxFailures(p.MaxFailures, tunables),
+		stop:        make(chan struct{}),
 	}
-	return h.lastMetric.Load()
+	if p.Metric != nil {
+		monitor.metricOverride = *p.Metric
+		monitor.hasMetricOverride = true
+	}
+	monitor.lastMetric.Store(INF)
+	go monitor.run()
+	return monitor
 }
+
+type pingPrefixHealthMonitor struct {
+	log               *slog.Logger
+	prefix            netip.Prefix
+	addr              netip.Addr
+	bindIf            string
+	delay             time.Duration
+	maxFailures       int
+	metricOverride    uint32
+	hasMetricOverride bool
+	lastMetric        atomic.Uint32
+	stop              chan struct{}
+	stopOnce          sync.Once
+}
+
+func (p *pingPrefixHealthMonitor) GetMetric() uint32 {
+	if p.hasMetricOverride {
+		return p.metricOverride
+	}
+	return p.lastMetric.Load()
+}
+
+func (p *pingPrefixHealthMonitor) Stop() {
+	p.stopOnce.Do(func() {
+		close(p.stop)
+	})
+}
+
+func (p *pingPrefixHealthMonitor) run() {
+	ticker := time.NewTicker(p.delay)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.stop:
+			return
+		case <-ticker.C:
+		}
+
+		bind4 := ""
+		bind6 := ""
+		var err error
+		if p.addr.Is6() {
+			if p.bindIf != "" {
+				bind6, err = GetIfIP(p.bindIf, true)
+			} else {
+				bind6 = "::"
+			}
+		} else {
+			if p.bindIf != "" {
+				bind4, err = GetIfIP(p.bindIf, false)
+			} else {
+				bind4 = "0.0.0.0"
+			}
+		}
+		if err != nil {
+			p.log.Error("failed to get bind address", "error", err)
+			continue
+		}
+		pinger, err := ping.New(bind4, bind6)
+		if err != nil {
+			p.log.Error("failed to start pinger", "error", err)
+			continue
+		}
+		rtt, err := pinger.PingAttempts(
+			&net.IPAddr{IP: net.IP(p.addr.AsSlice())},
+			time.Duration(int64(p.delay)/int64(p.maxFailures)),
+			p.maxFailures,
+		)
+		pinger.Close()
+		if err != nil {
+			p.lastMetric.Store(INF)
+			p.log.Debug("prefix healthcheck failed", "prefix", p.prefix.String(), "addr", p.addr.String(), "error", err)
+			continue
+		}
+		p.lastMetric.Store(DurationToMetric(rtt))
+	}
+}
+
+type HTTPPrefixHealth struct {
+	Prefix netip.Prefix   `yaml:"prefix"`
+	URL    string         `yaml:"url"`              // the URL to check
+	Delay  *time.Duration `yaml:"delay,omitempty"`  // delay between probes
+	Metric *uint32        `yaml:"metric,omitempty"` // metric override
+}
+
 func (h *HTTPPrefixHealth) GetPrefix() netip.Prefix {
 	return h.Prefix
 }
-func (h *HTTPPrefixHealth) Start(log *slog.Logger, t *RouterTunables) {
-	if h.running.Swap(true) {
-		return
-	}
-	h.lastMetric.Store(INF)
-	if h.Delay == nil {
-		h.Delay = &t.HealthCheckDelay
-	}
-	go func() {
-		ticker := time.NewTicker(*h.Delay)
-		defer ticker.Stop()
-		client := &http.Client{Timeout: *h.Delay}
-		for h.running.Load() { // TODO: add a way to interrupt this sleep, if ticker has a high delay
-			<-ticker.C
-			h.checkHTTP(log, client)
-		}
-	}()
-}
 
-func (h *HTTPPrefixHealth) checkHTTP(log *slog.Logger, client *http.Client) {
+func checkHTTPPrefix(log *slog.Logger, client *http.Client, prefix netip.Prefix, url string) uint32 {
 	startTime := time.Now()
-	resp, err := client.Get(h.URL)
+	resp, err := client.Get(url)
 	if err != nil {
-		h.lastMetric.Store(INF)
-		log.Debug("prefix healthcheck failed", "prefix", h.Prefix.String(), "url", h.URL, "error", err)
-		return
+		log.Debug("prefix healthcheck failed", "prefix", prefix.String(), "url", url, "error", err)
+		return INF
 	}
 	_, drainErr := io.Copy(io.Discard, resp.Body)
 	closeErr := resp.Body.Close()
 	if drainErr != nil {
-		log.Debug("failed to drain prefix healthcheck response", "prefix", h.Prefix.String(), "url", h.URL, "error", drainErr)
+		log.Debug("failed to drain prefix healthcheck response", "prefix", prefix.String(), "url", url, "error", drainErr)
 	}
 	if closeErr != nil {
-		log.Debug("failed to close prefix healthcheck response", "prefix", h.Prefix.String(), "url", h.URL, "error", closeErr)
+		log.Debug("failed to close prefix healthcheck response", "prefix", prefix.String(), "url", url, "error", closeErr)
 	}
 	if resp.StatusCode != http.StatusOK {
-		h.lastMetric.Store(INF)
-		log.Debug("prefix healthcheck failed", "prefix", h.Prefix.String(), "url", h.URL, "status", resp.StatusCode)
-		return
+		log.Debug("prefix healthcheck failed", "prefix", prefix.String(), "url", url, "status", resp.StatusCode)
+		return INF
 	}
-	rtt := time.Since(startTime)
-	h.lastMetric.Store(DurationToMetric(rtt))
+	return DurationToMetric(time.Since(startTime))
 }
 
-func (h *HTTPPrefixHealth) sameConfig(other PrefixHealth, tunables *RouterTunables) bool {
+func (h *HTTPPrefixHealth) sameConfig(other PrefixHealthConfig, tunables *RouterTunables) bool {
 	o, ok := other.(*HTTPPrefixHealth)
 	return ok &&
 		h.Prefix == o.Prefix &&
@@ -239,12 +241,79 @@ func (h *HTTPPrefixHealth) sameConfig(other PrefixHealth, tunables *RouterTunabl
 		prefixHealthDelay(h.Delay, tunables) == prefixHealthDelay(o.Delay, tunables)
 }
 
-type PrefixHealthWrapper struct {
-	PrefixHealth
+func (h *HTTPPrefixHealth) newMonitor(log *slog.Logger, tunables *RouterTunables, resolver *DNSResolver) PrefixHealthMonitor {
+	if resolver == nil {
+		resolver = NewDNSResolver(nil)
+	}
+	delay := prefixHealthDelay(h.Delay, tunables)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = resolver.DialContext
+	monitor := &httpPrefixHealthMonitor{
+		log:    log,
+		prefix: h.Prefix,
+		url:    h.URL,
+		delay:  delay,
+		client: &http.Client{
+			Timeout:   delay,
+			Transport: transport,
+		},
+		stop: make(chan struct{}),
+	}
+	if h.Metric != nil {
+		monitor.metricOverride = *h.Metric
+		monitor.hasMetricOverride = true
+	}
+	monitor.lastMetric.Store(INF)
+	go monitor.run()
+	return monitor
 }
 
-type prefixHealthConfig interface {
-	sameConfig(other PrefixHealth, tunables *RouterTunables) bool
+type httpPrefixHealthMonitor struct {
+	log               *slog.Logger
+	prefix            netip.Prefix
+	url               string
+	delay             time.Duration
+	client            *http.Client
+	metricOverride    uint32
+	hasMetricOverride bool
+	lastMetric        atomic.Uint32
+	stop              chan struct{}
+	stopOnce          sync.Once
+}
+
+func (h *httpPrefixHealthMonitor) GetMetric() uint32 {
+	if h.hasMetricOverride {
+		return h.metricOverride
+	}
+	return h.lastMetric.Load()
+}
+
+func (h *httpPrefixHealthMonitor) Stop() {
+	h.stopOnce.Do(func() {
+		close(h.stop)
+	})
+}
+
+func (h *httpPrefixHealthMonitor) run() {
+	ticker := time.NewTicker(h.delay)
+	defer ticker.Stop()
+	defer h.client.CloseIdleConnections()
+	for {
+		select {
+		case <-h.stop:
+			return
+		case <-ticker.C:
+			h.lastMetric.Store(checkHTTPPrefix(h.log, h.client, h.prefix, h.url))
+		}
+	}
+}
+
+type PrefixHealthWrapper struct {
+	PrefixHealth PrefixHealthConfig
+}
+
+func (p PrefixHealthWrapper) GetPrefix() netip.Prefix {
+	return p.PrefixHealth.GetPrefix()
 }
 
 // SameConfig reports whether two prefix health checks have equivalent configuration.
@@ -252,8 +321,19 @@ func (p PrefixHealthWrapper) SameConfig(other PrefixHealthWrapper, tunables *Rou
 	if p.PrefixHealth == nil || other.PrefixHealth == nil {
 		return p.PrefixHealth == other.PrefixHealth
 	}
-	config, ok := p.PrefixHealth.(prefixHealthConfig)
-	return ok && config.sameConfig(other.PrefixHealth, tunables)
+	return p.PrefixHealth.sameConfig(other.PrefixHealth, tunables)
+}
+
+func (p PrefixHealthWrapper) NewMonitor(log *slog.Logger, tunables *RouterTunables, resolver *DNSResolver) PrefixHealthMonitor {
+	return p.PrefixHealth.newMonitor(log, tunables, resolver)
+}
+
+func (p PrefixHealthWrapper) StaticMetric() (uint32, bool) {
+	config, ok := p.PrefixHealth.(*StaticPrefixHealth)
+	if !ok {
+		return 0, false
+	}
+	return config.Metric, true
 }
 
 func sameOptionalUint32(a, b *uint32) bool {

--- a/state/prefix_health_test.go
+++ b/state/prefix_health_test.go
@@ -145,13 +145,11 @@ func TestHTTPPrefixHealthClosesResponseBody(t *testing.T) {
 					}, nil
 				}),
 			}
-			health := &HTTPPrefixHealth{
-				Prefix: netip.MustParsePrefix("172.16.0.0/16"),
-				URL:    "http://example.com/health",
-			}
+			prefix := netip.MustParsePrefix("172.16.0.0/16")
+			url := "http://example.com/health"
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-			health.checkHTTP(logger, client)
+			checkHTTPPrefix(logger, client, prefix, url)
 
 			assert.True(t, body.closed)
 		})

--- a/state/utils_test.go
+++ b/state/utils_test.go
@@ -61,8 +61,8 @@ func SampleNetwork(t *testing.T, numClients, numRouters int, fullyConnected bool
 					},
 				},
 			},
-			Endpoints: []*DynamicEndpoint{
-				NewDynamicEndpoint(fmt.Sprintf("192.168.0.%d:25565", idx)),
+			Endpoints: []string{
+				fmt.Sprintf("192.168.0.%d:25565", idx),
 			},
 		})
 	}

--- a/state/validation.go
+++ b/state/validation.go
@@ -84,6 +84,11 @@ func CentralConfigValidator(cfg *CentralCfg) error {
 		if slices.Contains(nodes, string(node.Id)) {
 			return fmt.Errorf("duplicate router id %s", node.Id)
 		}
+		for _, endpoint := range node.Endpoints {
+			if _, _, err := parseEndpoint(endpoint); err != nil {
+				return fmt.Errorf("router %s has invalid endpoint: %w", node.Id, err)
+			}
+		}
 		nodes = append(nodes, string(node.Id))
 	}
 	for _, node := range cfg.Clients {

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -89,6 +89,24 @@ func TestCentralConfigValidator_OverlappingPrefix(t *testing.T) {
 	assert.NoError(t, CentralConfigValidator(cfg))
 }
 
+func TestCentralConfigValidator_Endpoint(t *testing.T) {
+	cfg := &CentralCfg{
+		Routers: []RouterCfg{{
+			NodeCfg: NodeCfg{Id: "node1"},
+			Endpoints: []string{
+				"example.com",
+				"example.com:57175",
+				"192.0.2.1",
+				"[2001:db8::1]:57175",
+			},
+		}},
+	}
+	assert.NoError(t, CentralConfigValidator(cfg))
+
+	cfg.Routers[0].Endpoints = []string{"http://example.com"}
+	assert.ErrorContains(t, CentralConfigValidator(cfg), "invalid endpoint")
+}
+
 func TestCentralConfigValidator_PassiveClientNonStaticPrefix(t *testing.T) {
 	cfg := &CentralCfg{
 		Clients: []ClientCfg{


### PR DESCRIPTION
Previously nylon structures populated runtime state inside of CentralCfg, which makes it more error prone to apply live config updates.