### PR TITLE
Check errors that were discarded before use

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -58,6 +58,9 @@ var keyCmd = &cobra.Command{
 		}
 		fmt.Println(string(privKeyStr))
 		pubKeyStr, err := privKey.Pubkey().MarshalText()
+		if err != nil {
+			panic(err)
+		}
 		_, err = fmt.Fprintln(os.Stderr, string(pubKeyStr))
 		if err != nil {
 			panic(err)

--- a/core/sys_darwin.go
+++ b/core/sys_darwin.go
@@ -11,6 +11,9 @@ import (
 
 func InitUAPI(logger *slog.Logger, itfName string) (net.Listener, error) {
 	fileUAPI, err := ipc.UAPIOpen(itfName)
+	if err != nil {
+		return nil, err
+	}
 
 	uapi, err := ipc.UAPIListen(itfName, fileUAPI)
 	if err != nil {

--- a/core/sys_linux.go
+++ b/core/sys_linux.go
@@ -12,6 +12,9 @@ import (
 
 func InitUAPI(logger *slog.Logger, itfName string) (net.Listener, error) {
 	fileUAPI, err := ipc.UAPIOpen(itfName)
+	if err != nil {
+		return nil, err
+	}
 
 	uapi, err := ipc.UAPIListen(itfName, fileUAPI)
 	if err != nil {

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -78,6 +78,9 @@ func BundleConfig(config string, rootKey NyPrivateKey) (string, error) {
 	cfg.Timestamp = time.Now().UnixNano()
 
 	plainText, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
 
 	bundle, err := SignBundle(plainText, rootKey)
 	if err != nil {


### PR DESCRIPTION
staticcheck (SA4006) flags four places where an error is assigned and then discarded before anything tests it. One of them turns a handled startup failure into a panic.

### `InitUAPI` panics instead of reporting why it failed

`core/sys_linux.go:14` and `core/sys_darwin.go:13` are identical:

```go
fileUAPI, err := ipc.UAPIOpen(itfName)   // err discarded

uapi, err := ipc.UAPIListen(itfName, fileUAPI)
```

`UAPIOpen` returns `(nil, err)` on four paths in `polyamide/ipc/uapi_unix.go`: `MkdirAll` on the socket directory, `ResolveUnixAddr`, `errors.New("unix socket in use")`, and `os.Remove` of a stale socket. The nil `*os.File` reaches `UAPIListen`, which calls `net.FileListener(file)`.

`net.FileListener(nil)` does not return an error, it panics. `net/file.go:36` reads `f.Name()` to build the error message before anything checks the file:

```
net.FileListener(0x0)
	/usr/lib/go/src/net/file.go:36
os.(*File).Name(...)
	/usr/lib/go/src/os/file.go:63
panic: runtime error: invalid memory address or nil pointer dereference
```

So the two likeliest ways to start nylon wrong both end in a nil-pointer stack trace rather than the message already written for them: starting a second instance on an interface that already has a UAPI socket gives `unix socket in use`, and starting without root fails the `MkdirAll`. `InitUAPI` has one caller, `core/sys_physical.go:55`, on the startup path.

Worth noting the darwin one is invisible to a normal `staticcheck ./...`, since it analyses a single GOOS and the build-tagged file is not in the package otherwise. It only appears under `GOOS=darwin`.

### The two smaller ones

- `cmd/utils.go:60` — `pubKeyStr, err := privKey.Pubkey().MarshalText()` is immediately followed by `_, err = fmt.Fprintln(...)`, so the marshal error is overwritten before it is tested. The private key branch just above does check it. On a failure, `nylon key` prints an empty public key to stderr and exits 0.
- `state/distribution.go:80` — `plainText, err := yaml.Marshal(cfg)` goes straight into `SignBundle(plainText, ...)`, so a marshal failure gets signed and sealed as empty bytes.

### Not touched

`polyamide/conn/bind_std.go:255` has the same SA4006 shape (`numMsgs`), but `polyamide/` is a vendored wireguard-go fork, so it seemed better left to an upstream sync than changed here.

### Verification

`go build ./...` and `GOOS=darwin go build ./...` both pass, `go test ./core/... ./state/...` is green before and after, `gofmt -l` is clean on all four files, and first-party SA4006 goes from 4 to 0.

I did not add a test. The UAPI path needs a real unix socket under the system socket directory, so a test would either need root or assert a failure that only reproduces without it, and would flip depending on how CI runs. If there is a pattern you use for the sys_* files, point me at it and I will add one.