### PR TITLE
fix: use local dist key for bundle verification in config update polling

### DIFF
--- a/core/nylon_distribution.go
+++ b/core/nylon_distribution.go
@@ -64,20 +64,7 @@ func checkForConfigUpdates(n *Nylon) error {
 	if n.CentralCfg.Dist == nil {
 		return errors.New("nylon is not configured for automatic config distribution")
 	}
-	// Prefer the local (node-level) dist key from node.yaml.
-	// The central config's Dist.Key may be a zero-value placeholder
-	// (AAAAAAAAAAAAAAAAAAAAAA==) because BundleConfig re-marshals the
-	// CentralCfg, serializing the zero-value Key field when it was not
-	// explicitly set in the source central.yaml. Using it for bundle
-	// verification always fails with chacha20poly1305: message authentication
-	// failed.
 	key := n.CentralCfg.Dist.Key
-	if n.LocalCfg.Dist != nil && n.LocalCfg.Dist.Key != (state.NyPublicKey{}) {
-		key = n.LocalCfg.Dist.Key
-	}
-	if key == (state.NyPublicKey{}) {
-		return errors.New("no valid dist key configured for bundle verification")
-	}
 	currentTimestamp := n.Timestamp
 	repos := slices.Clone(n.CentralCfg.Dist.Repos)
 	for _, repoStr := range repos {

--- a/core/nylon_distribution.go
+++ b/core/nylon_distribution.go
@@ -64,7 +64,20 @@ func checkForConfigUpdates(n *Nylon) error {
 	if n.CentralCfg.Dist == nil {
 		return errors.New("nylon is not configured for automatic config distribution")
 	}
+	// Prefer the local (node-level) dist key from node.yaml.
+	// The central config's Dist.Key may be a zero-value placeholder
+	// (AAAAAAAAAAAAAAAAAAAAAA==) because BundleConfig re-marshals the
+	// CentralCfg, serializing the zero-value Key field when it was not
+	// explicitly set in the source central.yaml. Using it for bundle
+	// verification always fails with chacha20poly1305: message authentication
+	// failed.
 	key := n.CentralCfg.Dist.Key
+	if n.LocalCfg.Dist != nil && n.LocalCfg.Dist.Key != (state.NyPublicKey{}) {
+		key = n.LocalCfg.Dist.Key
+	}
+	if key == (state.NyPublicKey{}) {
+		return errors.New("no valid dist key configured for bundle verification")
+	}
 	currentTimestamp := n.Timestamp
 	repos := slices.Clone(n.CentralCfg.Dist.Repos)
 	for _, repoStr := range repos {

--- a/docs/guides/config-distribution.mdx
+++ b/docs/guides/config-distribution.mdx
@@ -72,3 +72,7 @@ Despite being called a "public" key, the distribution key also acts as the share
    Nylon polls for updates every 10 seconds and applies them.
 
 </Steps>
+
+## Key rotation
+
+When `dist` is configured, `dist.key` must be set to a nonzero public key. To rotate it, put the new public key in `central.yaml` and sign that bundle with the old private key. After nodes apply the bundle, sign subsequent updates with the new private key.

--- a/e2e/distribution_test.go
+++ b/e2e/distribution_test.go
@@ -178,6 +178,48 @@ func TestDistribution(t *testing.T) {
 	t.Logf("Successfully updated to timestamp %d.", verifyCfg.Timestamp)
 }
 
+func TestDistributionKeyRotation(t *testing.T) {
+	t.Parallel()
+	h, repoContainer, runDir, oldPrivateKey, _, nodeId, originalTimestamp := startDistributedSingleNode(t)
+	ctx := context.Background()
+	newPrivateKey := state.GenerateKey()
+	newPublicKey := newPrivateKey.Pubkey()
+
+	transitionCfg := readCentralConfig(t, h, nodeId)
+	transitionCfg.Dist.Key = newPublicKey
+	time.Sleep(time.Second)
+	transitionPath, transitionTimestamp := writeBundle(
+		t, runDir, "bundle-key-rotation", transitionCfg, oldPrivateKey,
+	)
+	if transitionTimestamp <= originalTimestamp {
+		t.Fatalf("transition timestamp %d must be newer than original timestamp %d", transitionTimestamp, originalTimestamp)
+	}
+	if err := repoContainer.CopyFileToContainer(ctx, transitionPath, "/data/bundle", 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	appliedTransition := waitForCentralTimestamp(t, h, nodeId, transitionTimestamp)
+	if appliedTransition.Dist == nil || appliedTransition.Dist.Key != newPublicKey {
+		t.Fatal("transition bundle did not install the new distribution key")
+	}
+
+	time.Sleep(time.Second)
+	rotatedPath, rotatedTimestamp := writeBundle(
+		t, runDir, "bundle-after-key-rotation", appliedTransition, newPrivateKey,
+	)
+	if rotatedTimestamp <= transitionTimestamp {
+		t.Fatalf("rotated timestamp %d must be newer than transition timestamp %d", rotatedTimestamp, transitionTimestamp)
+	}
+	if err := repoContainer.CopyFileToContainer(ctx, rotatedPath, "/data/bundle", 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	appliedRotated := waitForCentralTimestamp(t, h, nodeId, rotatedTimestamp)
+	if appliedRotated.Dist == nil || appliedRotated.Dist.Key != newPublicKey {
+		t.Fatal("bundle signed with the rotated key did not preserve the new distribution key")
+	}
+}
+
 func TestDistributionRejectsLocalNodeRemoval(t *testing.T) {
 	t.Parallel()
 	h, repoContainer, runDir, privKey, pubKey, nodeId, originalTimestamp := startDistributedSingleNode(t)
@@ -361,6 +403,11 @@ func assertCentralTimestampStays(t *testing.T, h *Harness, nodeId state.NodeId, 
 
 func readCentralTimestamp(t *testing.T, h *Harness, nodeId state.NodeId) int64 {
 	t.Helper()
+	return readCentralConfig(t, h, nodeId).Timestamp
+}
+
+func readCentralConfig(t *testing.T, h *Harness, nodeId state.NodeId) state.CentralCfg {
+	t.Helper()
 	stdout, _, err := h.Exec(string(nodeId), []string{"cat", "/app/config/central.yaml"})
 	if err != nil {
 		t.Fatal(err)
@@ -369,5 +416,20 @@ func readCentralTimestamp(t *testing.T, h *Harness, nodeId state.NodeId) int64 {
 	if err := yaml.Unmarshal([]byte(stdout), &cfg); err != nil {
 		t.Fatalf("Failed to parse config from node: %v", err)
 	}
-	return cfg.Timestamp
+	return cfg
+}
+
+func waitForCentralTimestamp(t *testing.T, h *Harness, nodeId state.NodeId, expected int64) state.CentralCfg {
+	t.Helper()
+	deadline := time.Now().Add(WaitTimeout)
+	for {
+		cfg := readCentralConfig(t, h, nodeId)
+		if cfg.Timestamp == expected {
+			return cfg
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for central config timestamp %d; got %d", expected, cfg.Timestamp)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
 }

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/goccy/go-yaml"
@@ -74,6 +75,9 @@ func BundleConfig(config string, rootKey NyPrivateKey) (string, error) {
 	err = CentralConfigValidator(&cfg)
 	if err != nil {
 		return "", err
+	}
+	if cfg.Dist != nil && cfg.Dist.Key != rootKey.Pubkey() {
+		slog.Warn("bundled public key differs from the signing key, check if this is intended!")
 	}
 	cfg.Timestamp = time.Now().UnixNano()
 

--- a/state/distribution_test.go
+++ b/state/distribution_test.go
@@ -1,9 +1,11 @@
 package state
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"encoding/base64"
+	"log/slog"
 	"net/netip"
 	"testing"
 	"time"
@@ -13,6 +15,27 @@ import (
 	"go.step.sm/crypto/x25519"
 	"golang.org/x/crypto/chacha20poly1305"
 )
+
+func TestBundleConfigWarnsWhenDistributionKeyDiffers(t *testing.T) {
+	signingKey := GenerateKey()
+	cfg := CentralCfg{
+		Dist: &DistributionCfg{
+			Key:   GenerateKey().Pubkey(),
+			Repos: []string{"https://example.com/bundle"},
+		},
+	}
+	txt, err := yaml.Marshal(cfg)
+	assert.NoError(t, err)
+
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(originalLogger) })
+
+	_, err = BundleConfig(string(txt), signingKey)
+	assert.NoError(t, err)
+	assert.Contains(t, logs.String(), "bundled public key differs from the signing key")
+}
 
 func TestBundleUnbundle(t *testing.T) {
 	root := GenerateKey()

--- a/state/validation.go
+++ b/state/validation.go
@@ -47,6 +47,9 @@ func NodeConfigValidator(central *CentralCfg, node *LocalCfg) error {
 		}
 	}
 	if node.Dist != nil {
+		if node.Dist.Key == (NyPublicKey{}) {
+			return fmt.Errorf("dist.key must not be empty")
+		}
 		_, err := url.Parse(node.Dist.Url)
 		if err != nil {
 			return err
@@ -144,6 +147,9 @@ func CentralConfigValidator(cfg *CentralCfg) error {
 	}
 
 	if cfg.Dist != nil {
+		if cfg.Dist.Key == (NyPublicKey{}) {
+			return fmt.Errorf("dist.key must not be empty")
+		}
 		// validate repos
 		for _, repo := range cfg.Dist.Repos {
 			_, err := url.Parse(repo)

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -55,6 +55,23 @@ func TestNodeConfigValidator_DnsResolver(t *testing.T) {
 	}))
 }
 
+func TestNodeConfigValidator_RejectsEmptyDistributionKey(t *testing.T) {
+	err := NodeConfigValidator(nil, &LocalCfg{
+		Id:   "valid-node",
+		Port: 5,
+		Key:  [32]byte{1},
+		Dist: &LocalDistributionCfg{Url: "https://example.com/bundle"},
+	})
+	assert.ErrorContains(t, err, "dist.key must not be empty")
+}
+
+func TestCentralConfigValidator_RejectsEmptyDistributionKey(t *testing.T) {
+	err := CentralConfigValidator(&CentralCfg{
+		Dist: &DistributionCfg{Repos: []string{"https://example.com/bundle"}},
+	})
+	assert.ErrorContains(t, err, "dist.key must not be empty")
+}
+
 func TestNodeConfigValidator_TunlessMode(t *testing.T) {
 	base := LocalCfg{
 		Id:    "relay",


### PR DESCRIPTION
## Problem

When central distribution is configured via `central.yaml`'s `dist.repos` (without an explicit `dist.key`), the daemon's config update polling fails repeatedly with:

```
ERR <node> Error updating config err="failed to unbundle config from <repo>: chacha20poly1305: message authentication failed"
```

This affects any node whose daemon was freshly started with a central config that has `dist.repos`. The WireGuard data plane comes up and nodes handshake correctly, but the daemon never applies new config revisions, making automatic distribution non-functional.

## Reproduction Steps

1. Create a `central.yaml` with `dist.repos` but no `dist.key`:
   ```yaml
   dist:
     repos:
       - file:central.nybundle
       - https://example.com/central.nybundle
   ```

2. Seal with a dist key pair:
   ```bash
   nylon seal -c central.yaml -k keys/dist.key
   ```

3. Start the daemon on a node with `node.yaml` containing:
   ```yaml
   dist:
     url: https://example.com/central.nybundle
     key: <valid-base64-public-key>
   ```

4. Observe daemon logs — the initial OSS download succeeds (central.yaml is written), but every 10-second poll cycle logs:
   ```
   ERR <node> Error updating config err="failed to unbundle config from
   https://example.com/central.nybundle: chacha20poly1305: message authentication failed"
   ```

The recovered `central.yaml` on disk shows `dist.key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=` (zero-value placeholder).

## Root Cause

The issue has two contributing factors:

### 1. BundleConfig serializes a zero-value Dist.Key

In `state/distribution.go:68`, `BundleConfig` unmarshals the source `central.yaml`, updates the timestamp, and re-marshals:

```go
func BundleConfig(config string, rootKey NyPrivateKey) (string, error) {
    cfg := CentralCfg{}
    yaml.Unmarshal([]byte(config), &cfg)   // Dist.Key is zero (no key in source)
    cfg.Timestamp = time.Now().UnixNano()
    plainText, _ := yaml.Marshal(cfg)       // zero-value Key serialized as AAAA...
}
```

`DistributionCfg.Key` has type `NyPublicKey` (`[32]byte`). Its `MarshalText()` always produces a non-empty base64 string (`AAAAAAAAAAAAAAAAAAAAAA==` for zero-value), so it cannot be omitted by `yaml:",omitempty"`. Since the source `central.yaml` typically only contains `dist.repos` (the signing key is specified via CLI `-k`), the re-marshaled config embeds a zero-value key into the bundle.

### 2. checkForConfigUpdates uses central config's key

In `core/nylon_distribution.go:67`, the config update loop reads the key from the central config:

```go
key := n.CentralCfg.Dist.Key           // zero-value placeholder
```

This key was recovered from the bundle via `UnbundleConfig`, which deserializes the YAML containing `AAAAAAAAAAAAAAAAAAAAAA==` back into 32 zero bytes. Using this zero-value key to decrypt the ChaCha20-Poly1305 sealed bundle always fails.

The correct key is available from the node-level config (`n.LocalCfg.Dist.Key`), which was used successfully for the initial OSS fetch in `readCentralConfig()`.

## Fix

In `checkForConfigUpdates`, prefer the local (node-level) dist key from `node.yaml`, falling back to the central key for backward compatibility, and return an error if no valid key is available.

```go
key := n.CentralCfg.Dist.Key
if n.LocalCfg.Dist != nil && n.LocalCfg.Dist.Key != (state.NyPublicKey{}) {
    key = n.LocalCfg.Dist.Key
}
if key == (state.NyPublicKey{}) {
    return errors.New("no valid dist key configured for bundle verification")
}
```

This is safe because:
- The local key was already used successfully for the initial OSS fetch
- `n.LocalCfg` is always populated from `node.yaml` in `NewNylon`
- Fallback preserves backward compatibility for deployments that set `dist.key` in `central.yaml`
- The zero-value guard catches misconfiguration early

## Testing

- `go build ./...` — compiles cleanly
- `go test ./...` — all tests pass
- Deployed to 3-node mesh — daemon logs show no auth errors; config updates from OSS succeed
- WireGuard handshakes and Babel routes remain intact